### PR TITLE
chore: update ios copyright to 2024

### DIFF
--- a/ios/fastlane/metadata/copyright.txt
+++ b/ios/fastlane/metadata/copyright.txt
@@ -1,1 +1,1 @@
-2023 Infoteam.
+2024 Infoteam.


### PR DESCRIPTION
close #185