### PR TITLE
fix: `setState() called after dispose()` in notice body

### DIFF
--- a/lib/app/modules/notices/presentation/widgets/notice_body.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_body.dart
@@ -63,6 +63,7 @@ class _NoticeBodyState extends State<NoticeBody> {
           controller.addJavaScriptHandler(
             handlerName: 'Resize',
             callback: (arguments) {
+              if (!mounted) return;
               setState(() => _height = arguments.first.toDouble());
               if (!_completer.isCompleted) _completer.complete();
             },


### PR DESCRIPTION
close #174