### PR TITLE
fix: feed image placeholder

### DIFF
--- a/lib/app/modules/auth/data/data_source/remote/user_api.dart
+++ b/lib/app/modules/auth/data/data_source/remote/user_api.dart
@@ -31,5 +31,5 @@ abstract class UserApi {
   Future<TokenModel> refresh();
 
   @POST('fcm')
-  Future updateFcmToken(@Field('fcm_token') String fcmToken);
+  Future updateFcmToken(@Field() String fcmToken);
 }

--- a/lib/app/modules/auth/data/data_source/remote/user_api.dart
+++ b/lib/app/modules/auth/data/data_source/remote/user_api.dart
@@ -24,7 +24,7 @@ abstract class UserApi {
   Future<UserModel> info();
 
   @POST('logout')
-  Future logout();
+  Future logout(@Field('access_token') String accessToken);
 
   @POST('refresh')
   @Extra({AuthorizeInterceptor.retriedKey: true})

--- a/lib/app/modules/auth/data/repositories/remote_auth_repository.dart
+++ b/lib/app/modules/auth/data/repositories/remote_auth_repository.dart
@@ -42,7 +42,9 @@ class RemoteAuthRepository implements AuthRepository {
 
   @override
   Future<void> logout() async {
-    await _api.logout();
+    final accessToken = await _tokenRepository.token.first;
+    if (accessToken == null) return;
+    await _api.logout(accessToken);
     await _tokenRepository.deleteToken();
     _userController.add(null);
   }

--- a/lib/app/modules/notices/presentation/widgets/notice_card.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_card.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
@@ -166,10 +167,13 @@ class _ImageActionState extends State<_ImageAction> {
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(15),
-                child: Image.network(
-                  imagesUrl.first,
+                child: CachedNetworkImage(
+                  imageUrl: imagesUrl.first,
                   fit: BoxFit.fitWidth,
                   width: double.infinity,
+                  placeholder: (context, url) => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
image placeholder를 추가해서 로딩이 되지 않은 이미지가 공간을 차지할 수 있도록 개선하였습니다

최대 높이 (200)을 차지하고 있기 때문에 추후에 UX를 위해서는 백엔드와 함께 개선이 필요한 부분으로 보입니다