### PR TITLE
fix: v4 button height

### DIFF
--- a/lib/app/modules/common/presentation/widgets/ziggle_button.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_button.dart
@@ -74,6 +74,7 @@ class _ZiggleButtonState extends State<ZiggleButton> {
       style: const TextStyle(
         fontSize: 18,
         fontWeight: FontWeight.bold,
+        height: 1,
       ).copyWith(color: _effectiveColor),
       child: widget.child,
     );
@@ -98,7 +99,6 @@ class _ZiggleButtonState extends State<ZiggleButton> {
         scale: widget.onPressed != null && pressed ? 0.95 : 1,
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 100),
-          padding: widget.type.padding,
           width: widget.type == ZiggleButtonType.cta ? double.infinity : null,
           decoration: BoxDecoration(
             color: _effectiveBackgroundColor
@@ -114,10 +114,17 @@ class _ZiggleButtonState extends State<ZiggleButton> {
           child: Stack(
             alignment: Alignment.center,
             children: [
-              Opacity(opacity: widget.loading ? 0 : 1, child: inner),
-              Opacity(
-                opacity: widget.loading ? 1 : 0,
-                child: const CircularProgressIndicator(),
+              Padding(
+                padding: widget.type.padding,
+                child: Opacity(opacity: widget.loading ? 0 : 1, child: inner),
+              ),
+              Positioned.fill(
+                child: Center(
+                  child: Opacity(
+                    opacity: widget.loading ? 1 : 0,
+                    child: const CircularProgressIndicator(),
+                  ),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
with Positioned.fill


디자인상으로 높이가 50px정도인데, 실제 구현은 60px정도 나왔었습니다
로딩 위젯이 자리를 잡고 있어서 그랬기 때문에, Positioned.fill을 사용하고 Padding 위치를 옮겨서 Stack 위젯의 크기에 영향을 받지 않도록 하였습니다.
before:
![simulator_screenshot_B1F18B20-8FCA-47C8-A913-0D615044F021](https://github.com/user-attachments/assets/7ecd444f-a0a3-4041-b4df-b54b921195db)
after:
![simulator_screenshot_032EEF89-7C20-4486-A8F1-3B0FE20EE8BF](https://github.com/user-attachments/assets/ab5cd0ff-66e5-46ef-8428-d460d7427ee8)