### PR TITLE
feat: implement group detail page UI

### DIFF
--- a/assets/i18n/strings.i18n.json
+++ b/assets/i18n/strings.i18n.json
@@ -71,6 +71,18 @@
         "user": "User"
       },
       "banish": "Banish"
+    },
+    "detail": {
+      "appBar": {
+        "backLabel": "List",
+        "title": "Group Info"
+      },
+      "tab": {
+        "introduction": "Intro",
+        "notice": "Notice",
+        "member": "Member"
+      },
+      "favorite": "Favorite"
     }
   },
   "notice": {

--- a/assets/i18n/strings_jp.i18n.json
+++ b/assets/i18n/strings_jp.i18n.json
@@ -74,15 +74,15 @@
     },
     "detail": {
       "appBar": {
-        "backLabel": "-",
-        "title": "-"
+        "backLabel": "Список",
+        "title": "Информация о группе"
       },
       "tab": {
-        "introduction": "-",
-        "notice": "-",
-        "member": "-"
+        "introduction": "Введение",
+        "notice": "Объявления",
+        "member": "Участники"
       },
-      "favorite": "-"
+      "favorite": "Избранное"
     }
   },
   "notice": {

--- a/assets/i18n/strings_jp.i18n.json
+++ b/assets/i18n/strings_jp.i18n.json
@@ -71,6 +71,18 @@
         "user": "ユーザー"
       },
       "banish": "追放"
+    },
+    "detail": {
+      "appBar": {
+        "backLabel": "-",
+        "title": "-"
+      },
+      "tab": {
+        "introduction": "-",
+        "notice": "-",
+        "member": "-"
+      },
+      "favorite": "-"
     }
   },
   "notice": {
@@ -176,7 +188,7 @@
         "one": "あと$n秒",
         "other": "あと$n秒"
       },
-      "overdue": "期限超過"
+      "overdue": "期限切れ"
     },
     "detail": {
       "title": "お知らせの詳細",

--- a/assets/i18n/strings_ko.i18n.json
+++ b/assets/i18n/strings_ko.i18n.json
@@ -71,6 +71,18 @@
         "user": "일반"
       },
       "banish": "추방"
+    },
+    "detail": {
+      "appBar": {
+        "backLabel": "목록",
+        "title": "그룹 정보"
+      },
+      "tab": {
+        "introduction": "소개",
+        "notice": "공지",
+        "member": "멤버"
+      },
+      "favorite": "즐겨찾기"
     }
   },
   "notice": {

--- a/assets/i18n/strings_ru.i18n.json
+++ b/assets/i18n/strings_ru.i18n.json
@@ -71,6 +71,18 @@
         "user": "Пользователь"
       },
       "banish": "Исключить"
+    },
+    "detail": {
+      "appBar": {
+        "backLabel": "-",
+        "title": "-"
+      },
+      "tab": {
+        "introduction": "-",
+        "notice": "-",
+        "member": "-"
+      },
+      "favorite": "-"
     }
   },
   "notice": {

--- a/assets/i18n/strings_ru.i18n.json
+++ b/assets/i18n/strings_ru.i18n.json
@@ -74,15 +74,15 @@
     },
     "detail": {
       "appBar": {
-        "backLabel": "-",
-        "title": "-"
+        "backLabel": "リスト",
+        "title": "グループ情報"
       },
       "tab": {
-        "introduction": "-",
-        "notice": "-",
-        "member": "-"
+        "introduction": "紹介",
+        "notice": "お知らせ",
+        "member": "メンバー"
       },
-      "favorite": "-"
+      "favorite": "お気に入り"
     }
   },
   "notice": {

--- a/lib/app/modules/common/presentation/widgets/ziggle_tab_bar.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_tab_bar.dart
@@ -24,7 +24,7 @@ class ZiggleTabBar extends StatelessWidget {
       dividerColor: Palette.gray,
       splashFactory: NoSplash.splashFactory,
       overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-      labelPadding: const EdgeInsets.symmetric(vertical: 10),
+      labelPadding: const EdgeInsets.symmetric(vertical: 5),
       labelStyle: const TextStyle(
         fontSize: 16,
         fontWeight: FontWeight.w500,

--- a/lib/app/modules/groups/presentation/pages/group_detail_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_detail_page.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
+import 'package:ziggle/app/values/palette.dart';
+import 'package:ziggle/gen/strings.g.dart';
+
+class GroupDetailPage extends StatelessWidget {
+  const GroupDetailPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: ZiggleAppBar.compact(
+        backLabel: context.t.group.detail.appBar.backLabel,
+        title: Text(context.t.group.detail.appBar.title),
+      ),
+      body: DefaultTabController(
+        length: 3,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 0),
+          child: NestedScrollView(
+            headerSliverBuilder: (context, innerBoxIsScrolled) => [
+              SliverPersistentHeader(
+                pinned: false,
+                floating: true,
+                delegate: GroupInfoHeaderDelegate(),
+              ),
+              SliverPersistentHeader(
+                pinned: true,
+                delegate: MyTabBarDelegate(
+                  TabBar(
+                    labelStyle: const TextStyle(
+                      fontSize: 16,
+                      color: Palette.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    indicator: const BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(
+                          color: Palette.primary,
+                          width: 3,
+                        ),
+                      ),
+                    ),
+                    indicatorSize: TabBarIndicatorSize.tab,
+                    dividerColor: Palette.gray,
+                    dividerHeight: 3,
+                    tabs: <Tab>[
+                      Tab(text: context.t.group.detail.tab.introduction),
+                      Tab(text: context.t.group.detail.tab.notice),
+                      Tab(text: context.t.group.detail.tab.member),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+            body: TabBarView(
+              children: [
+                Builder(
+                  builder: (context) {
+                    return CustomScrollView(
+                      slivers: [
+                        SliverList.builder(
+                          itemCount: 20,
+                          itemBuilder: (context, index) {
+                            return ListTile(
+                              title: Text('Item $index'),
+                            );
+                          },
+                        ),
+                      ],
+                    );
+                  },
+                ),
+                const SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('소개 내용입니다.소개 내용입니다.'),
+                    ],
+                  ),
+                ),
+                Container(child: const Text('멤버 내용입니다.')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class GroupInfoHeaderDelegate extends SliverPersistentHeaderDelegate {
+  @override
+  double get minExtent => 250;
+
+  @override
+  double get maxExtent => 250;
+
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Container(
+              height: 90,
+              width: 90,
+              decoration: const BoxDecoration(
+                color: Colors.orange,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 15),
+            const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      '인포팀',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    SizedBox(width: 5),
+                    Icon(
+                      Icons.check,
+                    )
+                  ],
+                ),
+                Row(
+                  children: [
+                    Text(
+                      '구독자 n명 · 게시글 n개',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Palette.grayText,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            )
+          ],
+        ),
+        const SizedBox(height: 15),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 15),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            color: Palette.grayLight,
+          ),
+          child: const Column(
+            children: [
+              Text(
+                '지속 가능한 개발 문화를 통해 지스트 학부생의 삶의 질을 높이는 팀, 인포팀입니다.',
+                style: TextStyle(
+                  color: Palette.grayText,
+                  fontSize: 14,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 15),
+        Row(
+          children: [
+            Expanded(
+              child: ZiggleButton.cta(
+                onPressed: () {},
+                child: Text(context.t.group.detail.favorite),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
+    return false;
+  }
+}
+
+class MyTabBarDelegate extends SliverPersistentHeaderDelegate {
+  final TabBar tabBar;
+
+  MyTabBarDelegate(this.tabBar);
+
+  @override
+  double get minExtent => tabBar.preferredSize.height;
+
+  @override
+  double get maxExtent => tabBar.preferredSize.height;
+
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+      ),
+      child: tabBar,
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
+    return false;
+  }
+}

--- a/lib/app/modules/groups/presentation/pages/group_detail_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_detail_page.dart
@@ -115,7 +115,7 @@ class GroupDetailPage extends StatelessWidget {
                 child: Container(
                   color: Palette.white,
                   child: ZiggleTabBar(
-                    tabs: <Tab>[
+                    tabs: [
                       Tab(text: context.t.group.detail.tab.introduction),
                       Tab(text: context.t.group.detail.tab.notice),
                       Tab(text: context.t.group.detail.tab.member),
@@ -145,17 +145,17 @@ class GroupDetailPage extends StatelessWidget {
                 const SingleChildScrollView(
                   child: Column(
                     children: [
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
-                      Text('소개 내용입니다.소개 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
+                      Text('공지 내용입니다.공지 내용입니다.'),
                     ],
                   ),
                 ),

--- a/lib/app/modules/groups/presentation/pages/group_detail_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_detail_page.dart
@@ -1,9 +1,14 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_tab_bar.dart';
+import 'package:ziggle/app/modules/core/domain/enums/page_source.dart';
+import 'package:ziggle/app/modules/groups/presentation/widgets/sliver_pinned_box_adapter.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/strings.g.dart';
 
+@RoutePage()
 class GroupDetailPage extends StatelessWidget {
   const GroupDetailPage({super.key});
 
@@ -13,6 +18,8 @@ class GroupDetailPage extends StatelessWidget {
       appBar: ZiggleAppBar.compact(
         backLabel: context.t.group.detail.appBar.backLabel,
         title: Text(context.t.group.detail.appBar.title),
+        backgroundColor: Palette.white,
+        from: PageSource.unknown, // TODO
       ),
       body: DefaultTabController(
         length: 3,
@@ -20,31 +27,94 @@ class GroupDetailPage extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(16, 20, 16, 0),
           child: NestedScrollView(
             headerSliverBuilder: (context, innerBoxIsScrolled) => [
-              SliverPersistentHeader(
+              SliverPinnedBoxAdapter(
                 pinned: false,
-                floating: true,
-                delegate: GroupInfoHeaderDelegate(),
-              ),
-              SliverPersistentHeader(
-                pinned: true,
-                delegate: MyTabBarDelegate(
-                  TabBar(
-                    labelStyle: const TextStyle(
-                      fontSize: 16,
-                      color: Palette.primary,
-                      fontWeight: FontWeight.w500,
-                    ),
-                    indicator: const BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color: Palette.primary,
-                          width: 3,
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          height: 90,
+                          width: 90,
+                          decoration: const BoxDecoration(
+                            color: Colors.orange,
+                            shape: BoxShape.circle,
+                          ),
                         ),
+                        const SizedBox(width: 15),
+                        const Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Text(
+                                  '인포팀',
+                                  style: TextStyle(
+                                    fontSize: 24,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                SizedBox(width: 5),
+                                Icon(
+                                  Icons.check,
+                                )
+                              ],
+                            ),
+                            Row(
+                              children: [
+                                Text(
+                                  '구독자 n명 · 게시글 n개',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: Palette.grayText,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        )
+                      ],
+                    ),
+                    const SizedBox(height: 15),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 10, horizontal: 15),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Palette.grayLight,
+                      ),
+                      child: const Column(
+                        children: [
+                          Text(
+                            '지속 가능한 개발 문화를 통해 지스트 학부생의 삶의 질을 높이는 팀, 인포팀입니다.',
+                            style: TextStyle(
+                              color: Palette.grayText,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    indicatorSize: TabBarIndicatorSize.tab,
-                    dividerColor: Palette.gray,
-                    dividerHeight: 3,
+                    const SizedBox(height: 15),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: ZiggleButton.cta(
+                            onPressed: () {},
+                            child: Text(context.t.group.detail.favorite),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 15),
+                  ],
+                ),
+              ),
+              SliverPinnedBoxAdapter(
+                pinned: true,
+                child: Container(
+                  color: Palette.white,
+                  child: ZiggleTabBar(
                     tabs: <Tab>[
                       Tab(text: context.t.group.detail.tab.introduction),
                       Tab(text: context.t.group.detail.tab.notice),
@@ -96,129 +166,5 @@ class GroupDetailPage extends StatelessWidget {
         ),
       ),
     );
-  }
-}
-
-class GroupInfoHeaderDelegate extends SliverPersistentHeaderDelegate {
-  @override
-  double get minExtent => 250;
-
-  @override
-  double get maxExtent => 250;
-
-  @override
-  Widget build(
-      BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return Column(
-      children: [
-        Row(
-          children: [
-            Container(
-              height: 90,
-              width: 90,
-              decoration: const BoxDecoration(
-                color: Colors.orange,
-                shape: BoxShape.circle,
-              ),
-            ),
-            const SizedBox(width: 15),
-            const Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Text(
-                      '인포팀',
-                      style: TextStyle(
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    SizedBox(width: 5),
-                    Icon(
-                      Icons.check,
-                    )
-                  ],
-                ),
-                Row(
-                  children: [
-                    Text(
-                      '구독자 n명 · 게시글 n개',
-                      style: TextStyle(
-                        fontSize: 16,
-                        color: Palette.grayText,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            )
-          ],
-        ),
-        const SizedBox(height: 15),
-        Container(
-          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 15),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            color: Palette.grayLight,
-          ),
-          child: const Column(
-            children: [
-              Text(
-                '지속 가능한 개발 문화를 통해 지스트 학부생의 삶의 질을 높이는 팀, 인포팀입니다.',
-                style: TextStyle(
-                  color: Palette.grayText,
-                  fontSize: 14,
-                ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 15),
-        Row(
-          children: [
-            Expanded(
-              child: ZiggleButton.cta(
-                onPressed: () {},
-                child: Text(context.t.group.detail.favorite),
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  @override
-  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
-    return false;
-  }
-}
-
-class MyTabBarDelegate extends SliverPersistentHeaderDelegate {
-  final TabBar tabBar;
-
-  MyTabBarDelegate(this.tabBar);
-
-  @override
-  double get minExtent => tabBar.preferredSize.height;
-
-  @override
-  double get maxExtent => tabBar.preferredSize.height;
-
-  @override
-  Widget build(
-      BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return Container(
-      decoration: const BoxDecoration(
-        color: Colors.white,
-      ),
-      child: tabBar,
-    );
-  }
-
-  @override
-  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
-    return false;
   }
 }

--- a/lib/app/modules/groups/presentation/widgets/sliver_pinned_box_adapter.dart
+++ b/lib/app/modules/groups/presentation/widgets/sliver_pinned_box_adapter.dart
@@ -1,0 +1,62 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+class SliverPinnedBoxAdapter extends SingleChildRenderObjectWidget {
+  const SliverPinnedBoxAdapter({
+    super.key,
+    super.child,
+    this.pinned = true,
+  });
+
+  final bool pinned;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderSliverPinnedBoxAdapter(pinned: pinned);
+}
+
+class _RenderSliverPinnedBoxAdapter extends RenderSliverSingleBoxAdapter {
+  _RenderSliverPinnedBoxAdapter({required this.pinned});
+
+  final bool pinned;
+
+  double previousScrollOffset = 0;
+  double? ratchetingScrollDistance;
+
+  @override
+  void performLayout() {
+    child!.layout(constraints.asBoxConstraints(), parentUsesSize: true);
+    final childExtent = constraints.axis == Axis.horizontal
+        ? child!.size.width
+        : child!.size.height;
+    final paintedChildExtent = min(
+      childExtent,
+      constraints.remainingPaintExtent - constraints.overlap,
+    );
+
+    final dy = previousScrollOffset - constraints.scrollOffset;
+    previousScrollOffset = constraints.scrollOffset;
+
+    ratchetingScrollDistance = ratchetingScrollDistance == null
+        ? childExtent
+        : (ratchetingScrollDistance! + dy).clamp(0.0, childExtent);
+
+    geometry = SliverGeometry(
+      paintExtent: paintedChildExtent,
+      maxPaintExtent: childExtent,
+      maxScrollObstructionExtent: childExtent,
+      paintOrigin: pinned ? constraints.overlap : -constraints.scrollOffset,
+      scrollExtent: childExtent,
+      layoutExtent: max(0, paintedChildExtent - constraints.scrollOffset),
+      hasVisualOverflow: paintedChildExtent < childExtent,
+    );
+  }
+
+  @override
+  bool hitTestSelf(
+          {required double mainAxisPosition,
+          required double crossAxisPosition}) =>
+      true;
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -114,6 +114,10 @@ class AppRouter extends RootStackRouter {
           ),
         ],
       ),
+      AutoRoute(
+        path: '/group/detail',
+        page: GroupDetailRoute.page,
+      )
     ];
   }
 


### PR DESCRIPTION
close #360 

- [ ] [implement sliver pinned widget](https://gsainfoteam.slack.com/archives/C06MZ3CV15F/p1725355219432639?thread_ts=1725355216.139789&cid=C06MZ3CV15F)
- [ ] implement Ziggle Tab Bar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 그룹 세부 정보를 표시하는 `GroupDetailPage`가 추가되었습니다.
	- 그룹 관리 기능을 위한 다국어 지원이 향상되었습니다.
		- 새로운 "detail" 섹션이 추가되어 그룹 관련 기능에 대한 현지화 문자열이 포함되었습니다.
	- 새로운 라우트 `/group/detail`가 추가되어 그룹 세부 페이지로의 탐색이 가능해졌습니다.

- **버그 수정**
	- 일본어 로컬라이제이션의 "overdue" 키가 수정되었습니다.

- **문서화**
	- 여러 언어에 대한 그룹 관련 문자열이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->