### PR TITLE
feat: implement group member card

### DIFF
--- a/assets/i18n/common.i18n.json
+++ b/assets/i18n/common.i18n.json
@@ -14,5 +14,14 @@
       "one": "$n week",
       "other": "$n weeks"
     }
+  },
+  "memberCard" : {
+    "role" : {
+      "role" : "Role",
+      "admin" : "Admin",
+      "manager" : "Manager",
+      "user" : "User"
+    },
+    "banish" : "Banish"
   }
 }

--- a/assets/i18n/common_ko.i18n.json
+++ b/assets/i18n/common_ko.i18n.json
@@ -11,5 +11,14 @@
       "one": "일주일",
       "other": "$n주"
     }
+  },
+  "memberCard" : {
+    "role" : {
+      "role" : "역할",
+      "admin" : "관리자",
+      "manager" : "매니저",
+      "user" : "일반"
+    },
+    "banish" : "추방"
   }
 }

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_select.dart';
+import 'package:ziggle/app/values/palette.dart';
+import 'package:ziggle/gen/strings.g.dart';
+
+class GroupMemberCard extends StatelessWidget {
+  const GroupMemberCard({
+    super.key,
+    required this.name,
+    required this.email,
+    this.onPressed,
+  });
+
+  final String name;
+  final String email;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 15,
+        vertical: 15,
+      ),
+      decoration: ShapeDecoration(
+        color: Palette.grayLight,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            name,
+            style: const TextStyle(
+              color: Palette.black,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            email,
+            style: const TextStyle(
+              color: Palette.black,
+              fontSize: 14,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: ZiggleSelect(
+                    hintText: context.t.common.memberCard.role.role,
+                    entries: [
+                      ZiggleSelectEntry(
+                        value: 'admin',
+                        label: context.t.common.memberCard.role.admin,
+                      ),
+                      ZiggleSelectEntry(
+                        value: 'manager',
+                        label: context.t.common.memberCard.role.manager,
+                      ),
+                      ZiggleSelectEntry(
+                        value: 'user',
+                        label: context.t.common.memberCard.role.user,
+                      )
+                    ],
+                    small: true,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ZiggleButton.small(
+                  onPressed: onPressed,
+                  child: Text(context.t.common.memberCard.banish),
+                )
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/64c613b8-fecf-4c3e-b6c8-beda1ef48183



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 그룹 멤버 정보를 표시하는 `GroupMemberCard` 위젯 추가.
  - 사용자 역할(관리자, 매니저, 사용자) 선택 및 멤버 추방 기능 제공.
  - 애플리케이션의 초기 화면을 스플래시 화면으로 변경.

- **로컬라이제이션**
  - "memberCard" 관련 번역 추가 (영어 및 한국어).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->