### PR TITLE
fix: infinite load in android

### DIFF
--- a/lib/app/modules/user/data/repositories/flutter_secure_storage_token_repository.dart
+++ b/lib/app/modules/user/data/repositories/flutter_secure_storage_token_repository.dart
@@ -16,12 +16,17 @@ class FlutterSecureStorageTokenRepository implements TokenRepository {
   final _subject = BehaviorSubject<String?>();
   final _expiredAtSubject = BehaviorSubject<DateTime?>();
 
-  FlutterSecureStorageTokenRepository(this._storage) {
-    _storage.read(key: _tokenKey).then(_subject.add);
-    _storage
-        .read(key: _expiredAtKey)
-        .then((v) => v == null ? null : DateTime.parse(v))
-        .then(_expiredAtSubject.add);
+  FlutterSecureStorageTokenRepository(this._storage);
+
+  @PostConstruct(preResolve: true)
+  Future<void> init() async {
+    await Future.wait([
+      _storage.read(key: _tokenKey).then(_subject.add),
+      _storage
+          .read(key: _expiredAtKey)
+          .then((v) => v == null ? null : DateTime.parse(v))
+          .then(_expiredAtSubject.add),
+    ]);
   }
 
   static FutureOr dispose(TokenRepository repository) {


### PR DESCRIPTION
by make sure FlutterSecureStorageTokenRepository initialized during DI initialization

close #389 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 토큰 데이터의 초기화 로직을 개선하여 데이터 가용성 문제를 해결했습니다.
  
- **새로운 기능**
	- `FlutterSecureStorageTokenRepository` 클래스에 `init` 메서드를 추가하여 객체 초기화 후 안전하게 토큰과 만료 날짜를 읽을 수 있도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->