### PR TITLE
feat: Member Card Widget

### DIFF
--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -13,7 +13,6 @@ class GroupMemberCard extends StatelessWidget {
     required this.email,
     this.onPressed,
     required this.role,
-    this.editMode = false,
   });
 
   final String name;

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -13,20 +13,24 @@ class GroupMemberCard extends StatelessWidget {
     required this.email,
     this.onPressed,
     required this.role,
+    this.editMode = false,
   });
 
   final String name;
   final String email;
   final VoidCallback? onPressed;
   final GroupMemberRole? role;
+  final bool editMode;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: 15,
-        vertical: 15,
-      ),
+      padding: editMode
+          ? const EdgeInsets.symmetric(
+              horizontal: 15,
+              vertical: 15,
+            )
+          : const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
       decoration: ShapeDecoration(
         color: Palette.grayLight,
         shape: RoundedRectangleBorder(
@@ -36,59 +40,82 @@ class GroupMemberCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            name,
-            style: const TextStyle(
-              color: Palette.black,
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 2),
-          Text(
-            email,
-            style: const TextStyle(
-              color: Palette.black,
-              fontSize: 14,
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-          const SizedBox(
-            height: 10,
-          ),
-          IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  child: ZiggleSelect(
-                    value: role,
-                    hintText: context.t.common.memberCard.role.role,
-                    entries: [
-                      ZiggleSelectEntry(
-                        value: GroupMemberRole.admin,
-                        label: context.t.common.memberCard.role.admin,
-                      ),
-                      ZiggleSelectEntry(
-                        value: GroupMemberRole.manager,
-                        label: context.t.common.memberCard.role.manager,
-                      ),
-                      ZiggleSelectEntry(
-                        value: GroupMemberRole.user,
-                        label: context.t.common.memberCard.role.user,
-                      )
-                    ],
-                    small: true,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    name,
+                    style: const TextStyle(
+                      color: Palette.black,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    email,
+                    style: const TextStyle(
+                      color: Palette.black,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
+                ],
+              ),
+              if (editMode != true)
+                Padding(
+                  padding: const EdgeInsets.only(right: 5),
+                  child: Text(
+                    '$role',
+                    style: const TextStyle(
+                      color: Palette.grayText,
+                      fontSize: 14,
+                    ),
                   ),
                 ),
-                const SizedBox(width: 10),
-                ZiggleButton.small(
-                  onPressed: onPressed,
-                  child: Text(context.t.common.memberCard.banish),
-                )
-              ],
-            ),
-          )
+            ],
+          ),
+          SizedBox(
+            height: editMode ? 10 : 0,
+          ),
+          if (editMode)
+            IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    child: ZiggleSelect(
+                      value: role,
+                      hintText: context.t.common.memberCard.role.role,
+                      entries: [
+                        ZiggleSelectEntry(
+                          value: GroupMemberRole.admin,
+                          label: context.t.common.memberCard.role.admin,
+                        ),
+                        ZiggleSelectEntry(
+                          value: GroupMemberRole.manager,
+                          label: context.t.common.memberCard.role.manager,
+                        ),
+                        ZiggleSelectEntry(
+                          value: GroupMemberRole.user,
+                          label: context.t.common.memberCard.role.user,
+                        )
+                      ],
+                      small: true,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  ZiggleButton.small(
+                    onPressed: onPressed,
+                    child: Text(context.t.common.memberCard.banish),
+                  )
+                ],
+              ),
+            )
         ],
       ),
     );

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -110,21 +110,10 @@ class GroupMemberCard extends StatelessWidget {
                     child: ZiggleSelect(
                       value: role,
                       hintText: context.t.common.memberCard.role.role,
-                      entries: [
-                        ZiggleSelectEntry(
-                          value: GroupMemberRole.admin,
-                          label: context.t.common.memberCard.role.admin,
-                        ),
-                        ZiggleSelectEntry(
-                          value: GroupMemberRole.manager,
-                          label: context.t.common.memberCard.role.manager,
-                        ),
-                        ZiggleSelectEntry(
-                          value: GroupMemberRole.user,
-                          label: context.t.common.memberCard.role.user,
-                        )
-                      ],
-                      small: true,
+                      entries: GroupMemberRole.values
+                          .map((value) => ZiggleSelectEntry(
+                              value: value, label: value.label))
+                          .toList(),
                     ),
                   ),
                   const SizedBox(width: 10),

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -4,7 +4,26 @@ import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_select.dar
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/strings.g.dart';
 
-enum GroupMemberRole { admin, manager, user }
+enum GroupMemberRole {
+  admin('Admin'),
+  manager('Manager'),
+  user('User');
+
+  final String label;
+
+  const GroupMemberRole(this.label);
+
+  String toLocalizedString(BuildContext context) {
+    switch (this) {
+      case GroupMemberRole.admin:
+        return context.t.common.memberCard.role.admin;
+      case GroupMemberRole.manager:
+        return context.t.common.memberCard.role.manager;
+      case GroupMemberRole.user:
+        return context.t.common.memberCard.role.user;
+    }
+  }
+}
 
 class GroupMemberCard extends StatelessWidget {
   const GroupMemberCard({
@@ -12,14 +31,15 @@ class GroupMemberCard extends StatelessWidget {
     required this.name,
     required this.email,
     this.onPressed,
+    this.editMode = false,
     required this.role,
   });
 
   final String name;
   final String email;
   final VoidCallback? onPressed;
-  final GroupMemberRole? role;
   final bool editMode;
+  final GroupMemberRole role;
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +89,7 @@ class GroupMemberCard extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.only(right: 5),
                   child: Text(
-                    '$role',
+                    role.toLocalizedString(context),
                     style: const TextStyle(
                       color: Palette.grayText,
                       fontSize: 14,

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -26,20 +26,30 @@ enum GroupMemberRole {
 }
 
 class GroupMemberCard extends StatelessWidget {
-  const GroupMemberCard({
+  final String name;
+  final String email;
+  final VoidCallback? onBanish;
+  final bool editMode;
+  final GroupMemberRole role;
+  final ValueChanged<GroupMemberRole?>? onChanged;
+
+  const GroupMemberCard.editMode({
     super.key,
     required this.name,
     required this.email,
-    this.onPressed,
-    this.editMode = false,
     required this.role,
-  });
+    required this.onBanish,
+    required this.onChanged,
+  }) : editMode = true;
 
-  final String name;
-  final String email;
-  final VoidCallback? onPressed;
-  final bool editMode;
-  final GroupMemberRole role;
+  const GroupMemberCard.viewMode({
+    super.key,
+    required this.name,
+    required this.email,
+    required this.role,
+  })  : editMode = false,
+        onBanish = null,
+        onChanged = null;
 
   @override
   Widget build(BuildContext context) {
@@ -108,6 +118,7 @@ class GroupMemberCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: ZiggleSelect(
+                      onChanged: onChanged,
                       value: role,
                       hintText: context.t.common.memberCard.role.role,
                       entries: GroupMemberRole.values
@@ -118,7 +129,7 @@ class GroupMemberCard extends StatelessWidget {
                   ),
                   const SizedBox(width: 10),
                   ZiggleButton.small(
-                    onPressed: onPressed,
+                    onPressed: onBanish,
                     child: Text(context.t.common.memberCard.banish),
                   )
                 ],


### PR DESCRIPTION
close #371 
editMode를 기준으로 true and false를 변환할 수 있는 기능을 추가했습니다.

---

@2paperstar ZiggleSelectView에서 initial value를 선택할 수 있는 기능이 있나요?
기존 역할이 기본으로 선택되어 있는게 좋을 것 같아서요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- `ZiggleSelect` 위젯에 현재 선택된 값을 반영하는 기능 추가.
	- 그룹 리스트 아이템을 표시하는 새로운 `GroupListItem` 위젯 추가.
	- 그룹 멤버 카드에 역할을 선택할 수 있는 편집 모드 추가.
	- 멤버 역할에 대한 로컬라이즈된 문자열 표시 기능 추가.

- **사용자 인터페이스 개선**
	- 멤버 정보와 편집 옵션을 명확히 구분하여 사용자 경험 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->