### PR TITLE
fix: issues initial BehaviorSubject not set

### DIFF
--- a/lib/app/modules/user/data/repositories/flutter_secure_storage_token_repository.dart
+++ b/lib/app/modules/user/data/repositories/flutter_secure_storage_token_repository.dart
@@ -13,7 +13,7 @@ class FlutterSecureStorageTokenRepository implements TokenRepository {
   final FlutterSecureStorage _storage;
   static const _tokenKey = '_token';
   static const _expiredAtKey = '_expiredAt';
-  final _subject = BehaviorSubject<String?>();
+  final _subject = BehaviorSubject<String?>.seeded(null);
   final _expiredAtSubject = BehaviorSubject<DateTime?>();
 
   FlutterSecureStorageTokenRepository(this._storage) {


### PR DESCRIPTION
close #394 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `FlutterSecureStorageTokenRepository` 클래스의 `_subject` 변수가 초기 값으로 `null`로 설정되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->