### PR TITLE
feat: make ZiggleSelect controlled

### DIFF
--- a/lib/app/modules/common/presentation/widgets/ziggle_select.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_select.dart
@@ -26,12 +26,14 @@ class ZiggleSelect<T> extends StatefulWidget {
     required this.hintText,
     required this.entries,
     this.onChanged,
+    required this.value,
   });
 
   final bool small;
   final String hintText;
   final List<ZiggleSelectEntry<T>> entries;
-  final void Function(T?)? onChanged;
+  final T? value;
+  final ValueChanged<T?>? onChanged;
 
   @override
   State<ZiggleSelect<T>> createState() => _ZiggleSelectState<T>();
@@ -41,10 +43,13 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
   final _overlayController = OverlayPortalController();
   final _link = LayerLink();
   double? _buttonWidth;
-  ZiggleSelectEntry<T>? _value;
   ZiggleSelectEntry<T>? _hovering;
   bool _isHovering = false;
   bool _isRecentlyHovered = false;
+
+  ZiggleSelectEntry<T>? get _value => widget.value == null
+      ? null
+      : widget.entries.firstWhere((e) => e.value == widget.value);
 
   @override
   Widget build(BuildContext context) {
@@ -95,7 +100,6 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
                 return GestureDetector(
                   onTap: () {
                     widget.onChanged?.call(item?.value);
-                    setState(() => _value = item);
                     Future.delayed(
                       const Duration(milliseconds: 100),
                       () {
@@ -141,14 +145,14 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
                           style: TextStyle(
                             color: item == null
                                 ? Palette.grayText
-                                : item.value == _value?.value
+                                : item.value == widget.value
                                     ? Palette.primary
                                     : Palette.black,
                             fontSize: 16,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
-                        if (item != null && item.value == _value?.value)
+                        if (item != null && item.value == widget.value)
                           widget.small
                               ? Assets.icons.check.svg(width: 20, height: 20)
                               : Assets.icons.check.svg(width: 24, height: 24),
@@ -189,7 +193,8 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
             Text(
               _value?.label ?? widget.hintText,
               style: TextStyle(
-                color: _value == null ? Palette.grayText : Palette.primary,
+                color:
+                    widget.value == null ? Palette.grayText : Palette.primary,
                 fontSize: 16,
                 fontWeight: FontWeight.w500,
               ),

--- a/lib/app/modules/common/presentation/widgets/ziggle_select.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_select.dart
@@ -7,6 +7,16 @@ class ZiggleSelectEntry<T> {
   final String label;
 
   ZiggleSelectEntry({required this.value, required this.label});
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ZiggleSelectEntry<T> && other.value == value;
+  }
+
+  @override
+  int get hashCode => value.hashCode ^ label.hashCode;
 }
 
 class ZiggleSelect<T> extends StatefulWidget {

--- a/lib/app/modules/groups/presentation/pages/group_creation_done_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_creation_done_page.dart
@@ -79,6 +79,7 @@ class _LayoutState extends State<_Layout> {
               ),
               const SizedBox(height: 10),
               ZiggleSelect(
+                value: _duration,
                 onChanged: (v) => setState(() => _duration = v),
                 hintText: context.t.group.creation.done.invite.selectExpire,
                 entries: [

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -4,17 +4,21 @@ import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_select.dar
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/strings.g.dart';
 
+enum GroupMemberRole { admin, manager, user }
+
 class GroupMemberCard extends StatelessWidget {
   const GroupMemberCard({
     super.key,
     required this.name,
     required this.email,
     this.onPressed,
+    required this.role,
   });
 
   final String name;
   final String email;
   final VoidCallback? onPressed;
+  final GroupMemberRole? role;
 
   @override
   Widget build(BuildContext context) {
@@ -58,18 +62,19 @@ class GroupMemberCard extends StatelessWidget {
               children: [
                 Expanded(
                   child: ZiggleSelect(
+                    value: role,
                     hintText: context.t.common.memberCard.role.role,
                     entries: [
                       ZiggleSelectEntry(
-                        value: 'admin',
+                        value: GroupMemberRole.admin,
                         label: context.t.common.memberCard.role.admin,
                       ),
                       ZiggleSelectEntry(
-                        value: 'manager',
+                        value: GroupMemberRole.manager,
                         label: context.t.common.memberCard.role.manager,
                       ),
                       ZiggleSelectEntry(
-                        value: 'user',
+                        value: GroupMemberRole.user,
                         label: context.t.common.memberCard.role.user,
                       )
                     ],


### PR DESCRIPTION
close #395 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- `ZiggleSelect` 위젯이 선택된 값을 보다 직접적으로 관리하도록 업데이트되었습니다.
	- `GroupMemberCard`에 역할을 정의하는 새로운 열거형 `GroupMemberRole`이 추가되었습니다.

- **Bug Fixes**
	- `ZiggleSelect`의 초기 값으로 `_duration` 변수를 사용할 수 있도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->