### PR TITLE
chore: remove change account button in write notice config page

### DIFF
--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -74,8 +74,6 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage> {
             padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
             child: Column(
               children: [
-                _buildChangeAccount(),
-                const SizedBox(height: 25),
                 _buildDeadline(),
                 const SizedBox(height: 25),
                 _buildCategory(),
@@ -91,44 +89,6 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage> {
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildChangeAccount() {
-    return ZigglePressable(
-      onPressed: () {},
-      decoration: const BoxDecoration(
-        color: Palette.grayLight,
-        borderRadius: BorderRadius.all(Radius.circular(10)),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-        child: Row(
-          children: [
-            Assets.images.defaultProfile.image(width: 40),
-            const SizedBox(width: 10),
-            const Text(
-              '홍길동',
-              style: TextStyle(
-                color: Palette.black,
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const Spacer(),
-            Text(
-              context.t.notice.write.changeAccount,
-              style: const TextStyle(
-                color: Palette.grayText,
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(width: 5),
-            Assets.icons.navArrowRight.svg(),
-          ],
         ),
       ),
     );

--- a/lib/app/modules/user/presentation/pages/profile_page.dart
+++ b/lib/app/modules/user/presentation/pages/profile_page.dart
@@ -71,12 +71,6 @@ class _Layout extends StatelessWidget {
             const SizedBox(height: 40),
             ZiggleRowButton(
               icon: Assets.icons.setting.svg(),
-              title: const Text('create group'),
-              onPressed: () => const GroupCreationProfileRoute().push(context),
-            ),
-            const SizedBox(height: 20),
-            ZiggleRowButton(
-              icon: Assets.icons.setting.svg(),
               title: Text(context.t.user.setting.title),
               onPressed: () => const SettingRoute().push(context),
             ),


### PR DESCRIPTION
그룹 기능 공개 전에 임시로 삭제하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- 계정 정보 변경 UI 구성 요소가 제거되어 페이지 레이아웃이 간소화되었습니다.
	- "그룹 생성" 버튼이 프로필 페이지에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->