### PR TITLE
fix: show role label properly in group member widget

### DIFF
--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -120,10 +120,12 @@ class GroupMemberCard extends StatelessWidget {
                     child: ZiggleSelect(
                       onChanged: onChanged,
                       value: role,
+                      small: true,
                       hintText: context.t.common.memberCard.role.role,
                       entries: GroupMemberRole.values
                           .map((value) => ZiggleSelectEntry(
-                              value: value, label: value.label))
+                              value: value,
+                              label: value.toLocalizedString(context)))
                           .toList(),
                     ),
                   ),

--- a/lib/app/modules/groups/presentation/widgets/group_member_card.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_member_card.dart
@@ -5,13 +5,9 @@ import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/strings.g.dart';
 
 enum GroupMemberRole {
-  admin('Admin'),
-  manager('Manager'),
-  user('User');
-
-  final String label;
-
-  const GroupMemberRole(this.label);
+  admin,
+  manager,
+  user;
 
   String toLocalizedString(BuildContext context) {
     switch (this) {


### PR DESCRIPTION
close #371 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 그룹 멤버 카드의 역할 표시 방식이 간소화되었습니다.
	- 역할(enum)에서 레이블 문자열이 제거되고, 직접적으로 역할을 나열하도록 변경되었습니다.
	- `ZiggleSelect` 위젯의 렌더링에 영향을 미치는 새로운 속성 `small: true`가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->