### PR TITLE
fix: wrong additional notice deadline display condition

### DIFF
--- a/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
@@ -229,7 +229,7 @@ class NoticeRenderer extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 10),
-                    if (additional.deadline == null &&
+                    if (additional.deadline != null &&
                         additional.deadline != previousDeadline) ...[
                       Container(
                         padding: const EdgeInsets.symmetric(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 알림 표시 로직을 수정하여 `additional.deadline`이 null이 아닐 때만 특정 컨테이너가 표시되도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->