### PR TITLE
feat: initial value of tokenSubject in fcmMessagingRepository to null

### DIFF
--- a/lib/app/modules/core/data/repositories/fcm_messaging_repository.dart
+++ b/lib/app/modules/core/data/repositories/fcm_messaging_repository.dart
@@ -15,7 +15,7 @@ import 'package:ziggle/gen/strings.g.dart';
 
 @singleton
 class FcmMessagingRepository implements MessagingRepository, LinkRepository {
-  final _tokenSubject = BehaviorSubject<String?>();
+  final _tokenSubject = BehaviorSubject<String?>.seeded(null);
   final _linkSubject = BehaviorSubject<String?>();
   final FcmApi _api;
   static final _androidNotificationChannel = AndroidNotificationChannel(

--- a/lib/app/modules/user/data/repositories/flutter_secure_storage_token_repository.dart
+++ b/lib/app/modules/user/data/repositories/flutter_secure_storage_token_repository.dart
@@ -13,7 +13,7 @@ class FlutterSecureStorageTokenRepository implements TokenRepository {
   final FlutterSecureStorage _storage;
   static const _tokenKey = '_token';
   static const _expiredAtKey = '_expiredAt';
-  final _subject = BehaviorSubject<String?>.seeded(null);
+  final _subject = BehaviorSubject<String?>();
   final _expiredAtSubject = BehaviorSubject<DateTime?>();
 
   FlutterSecureStorageTokenRepository(this._storage);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ziggle
 description: ziggle
 publish_to: 'none'
-version: 4.0.1
+version: 4.0.2
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
close #414 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버전 업데이트**
	- 애플리케이션 버전이 4.0.1에서 4.0.2로 업데이트되었습니다.
  
- **변경 사항**
	- FCM 메시징 저장소의 초기 상태가 수정되어, `_tokenSubject`가 null로 초기화됩니다.
	- Flutter 보안 저장소의 초기 상태가 수정되어, `_subject`가 초기값 없이 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->