### PR TITLE
fix: prevent redirect to write page if user is not logged in

### DIFF
--- a/lib/app/modules/notices/presentation/pages/category_page.dart
+++ b/lib/app/modules/notices/presentation/pages/category_page.dart
@@ -1,10 +1,13 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:ziggle/app/modules/common/presentation/extensions/toast.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_pressable.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
+import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
 import 'package:ziggle/app/router.gr.dart';
 import 'package:ziggle/app/values/palette.dart';
+import 'package:ziggle/gen/strings.g.dart';
 
 @RoutePage()
 class CategoryPage extends StatelessWidget {
@@ -16,7 +19,14 @@ class CategoryPage extends StatelessWidget {
       backgroundColor: Palette.grayLight,
       appBar: ZiggleAppBar.main(
         onTapSearch: () => const SearchRoute().push(context),
-        onTapWrite: () => const NoticeWriteBodyRoute().push(context),
+        onTapWrite: () {
+          if (UserBloc.userOrNull(context) == null) {
+            return context.showToast(
+              context.t.user.login.description,
+            );
+          }
+          const NoticeWriteBodyRoute().push(context);
+        },
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),

--- a/lib/app/modules/notices/presentation/pages/feed_page.dart
+++ b/lib/app/modules/notices/presentation/pages/feed_page.dart
@@ -2,12 +2,15 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ziggle/app/di/locator.dart';
+import 'package:ziggle/app/modules/common/presentation/extensions/toast.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 import 'package:ziggle/app/modules/notices/presentation/bloc/notice_list_bloc.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/list_layout.dart';
+import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
 import 'package:ziggle/app/router.gr.dart';
 import 'package:ziggle/app/values/palette.dart';
+import 'package:ziggle/gen/strings.g.dart';
 
 @RoutePage()
 class FeedPage extends StatelessWidget {
@@ -19,7 +22,14 @@ class FeedPage extends StatelessWidget {
       backgroundColor: Palette.grayLight,
       appBar: ZiggleAppBar.main(
         onTapSearch: () => const SearchRoute().push(context),
-        onTapWrite: () => const NoticeWriteBodyRoute().push(context),
+        onTapWrite: () {
+          if (UserBloc.userOrNull(context) == null) {
+            return context.showToast(
+              context.t.user.login.description,
+            );
+          }
+          const NoticeWriteBodyRoute().push(context);
+        },
       ),
       body: BlocProvider(
         create: (_) => sl<NoticeListBloc>()


### PR DESCRIPTION
close #416
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자가 로그인하지 않은 경우, 공지 작성 기능으로의 접근을 제한하고 로그인 프롬프트 메시지를 표시하는 기능 추가.
	- `ZiggleAppBar`와 `CategoryPage`의 작성 버튼에 사용자 인증 체크 로직 추가.
  
- **버그 수정**
	- 로그인 상태에 따라 공지 작성 페이지로의 네비게이션을 조건부로 처리하여 사용자 경험 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->