### PR TITLE
feat: my notice page

### DIFF
--- a/assets/i18n/notice.i18n.json
+++ b/assets/i18n/notice.i18n.json
@@ -7,7 +7,7 @@
     "hot": "Ziggle Pick",
     "academic": "Academic",
     "all": "All",
-    "written": "Written"
+    "written": "My Notices"
   },
   "category(context=NoticeCategory)": {
     "academic": "Academic",

--- a/assets/i18n/notice_ko.i18n.json
+++ b/assets/i18n/notice_ko.i18n.json
@@ -7,7 +7,7 @@
     "hot": "지글픽",
     "academic": "학사",
     "all": "전체",
-    "written": "내가 쓴 공지"
+    "written": "내가 쓴 공지들"
   },
   "category(context=NoticeCategory)": {
     "academic": "학사",

--- a/assets/i18n/user.i18n.json
+++ b/assets/i18n/user.i18n.json
@@ -25,6 +25,7 @@
       "copyright": "GIST Students' Association, Infoteam"
     }
   },
+  "written": "My Notices",
   "feedback": "Feedback · Report a bug",
   "account": {
     "title": "Account",

--- a/assets/i18n/user_ko.i18n.json
+++ b/assets/i18n/user_ko.i18n.json
@@ -25,6 +25,7 @@
       "copyright": "학생회 정보국, 인포팀"
     }
   },
+  "written": "내가 쓴 공지들",
   "feedback": "피드백 · 버그 제보하기",
   "account": {
     "title": "계정",

--- a/lib/app/modules/user/presentation/pages/profile_page.dart
+++ b/lib/app/modules/user/presentation/pages/profile_page.dart
@@ -78,6 +78,7 @@ class _Layout extends StatelessWidget {
             if (authenticated) ...[
               const SizedBox(height: 20),
               ZiggleRowButton(
+                icon: Assets.icons.write.svg(),
                 title: Text(context.t.user.written),
                 onPressed: () =>
                     ListRoute(type: NoticeType.written).push(context),

--- a/lib/app/modules/user/presentation/pages/profile_page.dart
+++ b/lib/app/modules/user/presentation/pages/profile_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_row_button.dart';
+import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/auth_bloc.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
@@ -74,6 +75,14 @@ class _Layout extends StatelessWidget {
               title: Text(context.t.user.setting.title),
               onPressed: () => const SettingRoute().push(context),
             ),
+            if (authenticated) ...[
+              const SizedBox(height: 20),
+              ZiggleRowButton(
+                title: Text(context.t.user.written),
+                onPressed: () =>
+                    ListRoute(type: NoticeType.written).push(context),
+              ),
+            ],
             const SizedBox(height: 20),
             ZiggleRowButton(
               icon: Assets.icons.flag.svg(),


### PR DESCRIPTION
close #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 프로필 페이지에 "내가 쓴 공지들"로 이동하는 버튼 추가 (인증된 사용자만 표시됨).
	- 사용자 인터페이스에 "내가 쓴 공지들" 레이블 추가 (영어 및 한국어 지원).
  
- **문서화**
	- 국제화 관련 JSON 파일의 레이블 업데이트 (영어 및 한국어).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->