### PR TITLE
fix: remove current toast before show new one

### DIFF
--- a/lib/app/modules/common/presentation/extensions/toast.dart
+++ b/lib/app/modules/common/presentation/extensions/toast.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 extension BuildContextX on BuildContext {
   void showToast(String message) {
-    ScaffoldMessenger.of(this).showSnackBar(
-      SnackBar(
-        content: Text(message),
-      ),
-    );
+    ScaffoldMessenger.of(this)
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+        ),
+      );
   }
 }


### PR DESCRIPTION
close #426 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 새로운 메시지를 표시하기 전에 기존 스낵바를 지우도록 `showToast` 메서드가 수정되어, 동시에 여러 스낵바가 표시되는 문제를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->