### PR TITLE
fix: single notice shell PathParam missing

### DIFF
--- a/lib/app/modules/notices/presentation/layouts/single_notice_shell_layout.dart
+++ b/lib/app/modules/notices/presentation/layouts/single_notice_shell_layout.dart
@@ -9,7 +9,7 @@ import 'package:ziggle/app/modules/notices/presentation/bloc/notice_bloc.dart';
 class SingleNoticeShellLayout extends StatelessWidget {
   SingleNoticeShellLayout({
     super.key,
-    int? id,
+    @PathParam() int? id,
     NoticeEntity? notice,
   })  : assert(id != null || notice != null),
         id = id ?? notice!.id,


### PR DESCRIPTION
close #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 공지 사항 레이아웃의 생성자 매개변수에 경로 매개변수 주석 추가.
	- `id` 또는 `notice`가 제공되도록 하는 로직 개선.
- **버그 수정**
	- `id`가 null일 경우 `notice` 객체에서 `id`를 할당하도록 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->