### PR TITLE
fix: connect scroll controller in ZiggleSelect

### DIFF
--- a/lib/app/modules/common/presentation/widgets/ziggle_select.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_select.dart
@@ -46,6 +46,7 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
   ZiggleSelectEntry<T>? _hovering;
   bool _isHovering = false;
   bool _isRecentlyHovered = false;
+  final _scrollController = ScrollController();
 
   ZiggleSelectEntry<T>? get _value => widget.value == null
       ? null
@@ -89,8 +90,10 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxHeight: 200),
           child: Scrollbar(
+            controller: _scrollController,
             thumbVisibility: true,
             child: ListView.builder(
+              controller: _scrollController,
               shrinkWrap: true,
               padding: EdgeInsets.zero,
               itemCount: widget.entries.length + 1,


### PR DESCRIPTION
close #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `ZiggleSelect` 위젯에 스크롤바가 추가되어 사용자 인터페이스가 개선되었습니다.
	- 스크롤 동작을 관리하기 위한 새로운 `ScrollController`가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->