### PR TITLE
fix: wrong padding in group creation layout on rounded device

### DIFF
--- a/lib/app/modules/groups/presentation/layouts/group_creation_layout.dart
+++ b/lib/app/modules/groups/presentation/layouts/group_creation_layout.dart
@@ -19,13 +19,17 @@ class GroupCreationLayout extends StatelessWidget {
     return Scaffold(
       body: Column(
         children: [
-          Hero(
-            tag: 'group creation app bar',
-            child: Material(
-              color: Colors.transparent,
-              child: ZiggleAppBar.compact(
-                backLabel: context.t.common.cancel,
-                title: Text(context.t.group.creation.title),
+          MediaQuery.removePadding(
+            context: context,
+            removeBottom: true,
+            child: Hero(
+              tag: 'group creation app bar',
+              child: Material(
+                color: Colors.transparent,
+                child: ZiggleAppBar.compact(
+                  backLabel: context.t.common.cancel,
+                  title: Text(context.t.group.creation.title),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
close #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 그룹 생성 레이아웃의 앱 바에서 하단 패딩을 제거하여 더 깔끔한 표시를 구현했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->