### PR TITLE
fix: notice created at in NoticeCard and detail page

### DIFF
--- a/lib/app/modules/notices/presentation/widgets/created_at.dart
+++ b/lib/app/modules/notices/presentation/widgets/created_at.dart
@@ -6,9 +6,17 @@ import 'package:ziggle/app/modules/common/presentation/functions/noop.dart';
 import 'package:ziggle/app/values/palette.dart';
 
 class CreatedAt extends StatefulWidget {
-  const CreatedAt({super.key, required this.createdAt});
+  const CreatedAt({
+    super.key,
+    required this.createdAt,
+    this.style = const TextStyle(
+      fontWeight: FontWeight.w500,
+      color: Palette.grayText,
+    ),
+  });
 
   final DateTime createdAt;
+  final TextStyle style;
 
   @override
   State<CreatedAt> createState() => _CreatedAtState();
@@ -33,10 +41,7 @@ class _CreatedAtState extends State<CreatedAt> {
   Widget build(BuildContext context) {
     return Text(
       widget.createdAt.getTimeAgo(context),
-      style: const TextStyle(
-        fontWeight: FontWeight.w500,
-        color: Palette.grayText,
-      ),
+      style: widget.style,
     );
   }
 }

--- a/lib/app/modules/notices/presentation/widgets/notice_card.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_pressable.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_reaction.dart';
+import 'package:ziggle/app/modules/notices/presentation/widgets/created_at.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/d_day.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
@@ -61,9 +62,9 @@ class NoticeCard extends StatelessWidget {
                         ],
                       ),
                       const SizedBox(height: 2),
-                      const Text(
-                        '10분 전',
-                        style: TextStyle(
+                      CreatedAt(
+                        createdAt: notice.createdAt,
+                        style: const TextStyle(
                           fontSize: 12,
                           color: Palette.gray,
                         ),

--- a/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
@@ -11,7 +11,6 @@ import 'package:ziggle/app/modules/notices/domain/enums/notice_reaction.dart';
 import 'package:ziggle/app/modules/notices/presentation/bloc/notice_bloc.dart';
 import 'package:ziggle/app/modules/notices/presentation/cubit/copy_link_cubit.dart';
 import 'package:ziggle/app/modules/notices/presentation/cubit/share_cubit.dart';
-import 'package:ziggle/app/modules/notices/presentation/widgets/created_at.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/notice_body.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/tag.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
@@ -85,26 +84,29 @@ class NoticeRenderer extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Assets.images.defaultProfile.image(width: 36),
-                const SizedBox(width: 8),
-                Text(
-                  notice.author.name,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w500,
-                    color: Palette.black,
-                  ),
+                Assets.images.defaultProfile.image(width: 48),
+                const SizedBox(width: 10),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      notice.author.name,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                        color: Palette.black,
+                      ),
+                    ),
+                    Text(
+                      DateFormat.yMd().add_Hm().format(notice.createdAt),
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: Palette.grayText,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 5),
-                const Text(
-                  '·',
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    color: Palette.grayText,
-                  ),
-                ),
-                const SizedBox(width: 5),
-                CreatedAt(createdAt: notice.createdAt),
               ],
             ),
           ),


### PR DESCRIPTION
close #437
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `CreatedAt` 위젯에 스타일 매개변수가 추가되어 텍스트 스타일을 사용자 정의할 수 있게 되었습니다.
	- `NoticeCard` 위젯에서 정적 텍스트 대신 `CreatedAt` 위젯을 사용하여 생성 날짜를 표시합니다.
	- `NoticeRenderer` 위젯에서 작성자 정보 표시 방식이 개선되고, 작성 날짜가 추가되었습니다.

- **버그 수정**
	- 작성자 이미지 크기 및 요소 간 간격 조정으로 시각적 일관성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->