### PR TITLE
fix: show created at in additional notice

### DIFF
--- a/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
@@ -234,14 +234,29 @@ class NoticeRenderer extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Text(
-                      context.t.notice.additional.title,
-                      style: const TextStyle(
-                        height: 1,
-                        fontSize: 20,
-                        color: Palette.black,
-                        fontWeight: FontWeight.w600,
-                      ),
+                    Row(
+                      children: [
+                        Text(
+                          context.t.notice.additional.title,
+                          style: const TextStyle(
+                            height: 1,
+                            fontSize: 20,
+                            color: Palette.black,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Text(
+                          DateFormat.yMd()
+                              .add_Hm()
+                              .format(additional.createdAt.toLocal()),
+                          style: const TextStyle(
+                            fontSize: 16,
+                            color: Palette.grayText,
+                            fontWeight: FontWeight.w400,
+                          ),
+                        ),
+                      ],
                     ),
                     const SizedBox(height: 10),
                     if (additional.deadline != null &&


### PR DESCRIPTION
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-10-03 at 23 33 18](https://github.com/user-attachments/assets/257091c4-cb39-4daf-bf4c-b6a357100b92)
close #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 추가 콘텐츠의 제목과 생성 날짜를 함께 표시하여 사용자 인터페이스 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->