### PR TITLE
fix(ci/cd): remove `env.run` in `upload.yml`

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -66,7 +66,6 @@ jobs:
           channel: 'stable'
           cache: true
       - uses: actions/cache@v4
-        if: env.run == 'true'
         with:
           path: |
             .dart_tool
@@ -75,7 +74,7 @@ jobs:
       - name: install flutterfire
         run: flutter pub global activate flutterfire_cli
       - uses: actions/cache@v4
-        if: env.run == 'true' && matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14'
         with:
           path: |
             ~/.cocoapods
@@ -83,7 +82,6 @@ jobs:
           key: cocoapods-${{ hashFiles('ios/Podfile.lock') }}
 
       - name: Copy dotenv
-        if: env.run == 'true'
         run: cat ${{ secrets.DOTENV }} > .env
 
       - name: Generate files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 워크플로우에서 캐싱 조건을 조정하여 macOS 환경에서의 Dart 도구 캐시가 항상 실행되도록 수정했습니다.
	- CocoaPods 캐시 단계가 macOS 환경에서 항상 실행되도록 변경되었습니다.

- **기능 개선**
	- OS에 따라 환경 변수를 설정하는 조건부 단계를 추가하여 워크플로우를 간소화했습니다.
	- 환경 설정 및 빌드 단계에서 조건을 정제하여 필수 단계가 OS에 따라 적절하게 실행되도록 보장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->