### PR TITLE
fix: make bottom navigation bar not scrollable

### DIFF
--- a/lib/app/modules/common/presentation/pages/ziggle_bottom_navigation_page.dart
+++ b/lib/app/modules/common/presentation/pages/ziggle_bottom_navigation_page.dart
@@ -26,6 +26,7 @@ class _ZiggleBottomNavigationPageState extends State<ZiggleBottomNavigationPage>
   @override
   Widget build(BuildContext context) {
     return AutoTabsRouter.tabBar(
+      physics: const NeverScrollableScrollPhysics(),
       routes: const [
         FeedRoute(),
         CategoryRoute(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ziggle
 description: ziggle
 publish_to: 'none'
-version: 4.0.5
+version: 4.0.6
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
resolve #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 하단 내비게이션 바의 스크롤링 비활성화: 사용자가 탭 바를 스크롤할 수 없도록 변경되었습니다.
	- 분석 이벤트 추가: 하단 내비게이션 아이템 클릭 시 올바른 분석 이벤트가 기록되도록 개선되었습니다.
- **버그 수정**
	- 버전 업데이트: `4.0.5`에서 `4.0.6`으로 버전 번호가 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->