### PR TITLE
fix: record smartlook

### DIFF
--- a/lib/app/modules/core/data/repositories/amplitude_analytics_repository.dart
+++ b/lib/app/modules/core/data/repositories/amplitude_analytics_repository.dart
@@ -6,7 +6,7 @@ import 'package:ziggle/app/modules/core/domain/repositories/analytics_repository
 import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
 import 'package:ziggle/app/values/strings.dart';
 
-@singleton
+@lazySingleton
 class AmplitudeAnalyticsRepository implements AnalyticsRepository {
   late final _instance = Amplitude.getInstance()..init(Strings.amplitudeApiKey);
 

--- a/lib/app/modules/core/data/repositories/firebase_analytics_repository.dart
+++ b/lib/app/modules/core/data/repositories/firebase_analytics_repository.dart
@@ -6,7 +6,7 @@ import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
 
 import '../../domain/repositories/analytics_repository.dart';
 
-@singleton
+@lazySingleton
 class FirebaseAnalyticsRepository implements AnalyticsRepository {
   static final _analytics = FirebaseAnalytics.instance;
 

--- a/lib/app/modules/core/data/repositories/smartlook_analytics_repository.dart
+++ b/lib/app/modules/core/data/repositories/smartlook_analytics_repository.dart
@@ -9,6 +9,11 @@ import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
 class SmartlookAnalyticsRepository implements AnalyticsRepository {
   final _instance = Smartlook.instance;
 
+  @PostConstruct(preResolve: true)
+  void init() {
+    _instance.start();
+  }
+
   @override
   logChangeUser(UserEntity? user) {
     if (user == null) return;

--- a/lib/app/modules/core/data/repositories/smartlook_analytics_repository.dart
+++ b/lib/app/modules/core/data/repositories/smartlook_analytics_repository.dart
@@ -5,11 +5,11 @@ import 'package:ziggle/app/modules/core/domain/enums/event_type.dart';
 import 'package:ziggle/app/modules/core/domain/repositories/analytics_repository.dart';
 import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
 
-@singleton
+@lazySingleton
 class SmartlookAnalyticsRepository implements AnalyticsRepository {
   final _instance = Smartlook.instance;
 
-  @PostConstruct(preResolve: true)
+  @postConstruct
   void init() {
     _instance.start();
   }


### PR DESCRIPTION
resolve #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- `SmartlookAnalyticsRepository` 클래스에 `init` 메서드 추가, Smartlook 인스턴스를 초기화합니다.
- **변경 사항**
	- `AmplitudeAnalyticsRepository`, `FirebaseAnalyticsRepository`, `SmartlookAnalyticsRepository` 클래스의 인스턴스화 방식이 `@singleton`에서 `@lazySingleton`으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->