### PR TITLE
fix: android webview rendering issue

### DIFF
--- a/lib/app/modules/notices/presentation/widgets/notice_body.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_body.dart
@@ -18,7 +18,7 @@ class NoticeBody extends StatefulWidget {
 }
 
 class _NoticeBodyState extends State<NoticeBody> {
-  double _height = 0;
+  double _height = 1;
   late bool _initial = Platform.isIOS;
   final _completer = Completer<void>();
   late final InAppWebViewController _controller;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ziggle
 description: ziggle
 publish_to: 'none'
-version: 4.0.6
+version: 4.0.7
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
fix #461

height이 0인 경우에 webview가 렌더링 되지 않아서 생긴 이슈입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `NoticeBody` 위젯의 초기 높이를 `0`에서 `1`로 변경하여 레이아웃 개선.
  
- **버전 업데이트**
	- 프로젝트 버전이 `4.0.6`에서 `4.0.7`로 업데이트됨.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->