### PR TITLE
fix: AI Translation button not disappear when english content filled

### DIFF
--- a/lib/app/modules/notices/presentation/pages/notice_edit_body_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_edit_body_page.dart
@@ -259,6 +259,7 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
             bodyFocusNode: _koreanBodyFocusNode,
             titleController: _koreanTitleController,
             bodyController: _koreanBodyController,
+            isTranslateEnabled: false,
           ),
           Editor(
             titleDisabled: _prevNotice.contents[Language.en] != null,
@@ -270,6 +271,10 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
                   .isNotEmpty) return;
               _translate();
             },
+            isTranslateEnabled: _englishBodyController
+                .plainTextEditingValue.text
+                .trim()
+                .isEmpty,
             titleFocusNode: _englishTitleFocusNode,
             bodyFocusNode: _englishBodyFocusNode,
             titleController: _englishTitleController,

--- a/lib/app/modules/notices/presentation/pages/notice_edit_body_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_edit_body_page.dart
@@ -259,7 +259,6 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
             bodyFocusNode: _koreanBodyFocusNode,
             titleController: _koreanTitleController,
             bodyController: _koreanBodyController,
-            isTranslateEnabled: false,
           ),
           Editor(
             titleDisabled: _prevNotice.contents[Language.en] != null,
@@ -271,8 +270,7 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
                   .isNotEmpty) return;
               _translate();
             },
-            isTranslateEnabled: _englishBodyController
-                .plainTextEditingValue.text
+            translateEnabled: _englishBodyController.plainTextEditingValue.text
                 .trim()
                 .isEmpty,
             titleFocusNode: _englishTitleFocusNode,

--- a/lib/app/modules/notices/presentation/pages/notice_write_body_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_body_page.dart
@@ -291,6 +291,7 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
             bodyFocusNode: _koreanBodyFocusNode,
             titleController: _koreanTitleController,
             bodyController: _koreanBodyController,
+            isTranslateEnabled: false,
           ),
           BlocBuilder<AiBloc, AiState>(
             builder: (context, state) => Editor(
@@ -303,6 +304,10 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
                     const AnalyticsEvent.writeUseAiTranslation());
                 _translate();
               },
+              isTranslateEnabled: _englishBodyController
+                  .plainTextEditingValue.text
+                  .trim()
+                  .isEmpty,
               titleFocusNode: _englishTitleFocusNode,
               bodyFocusNode: _englishBodyFocusNode,
               titleController: _englishTitleController,

--- a/lib/app/modules/notices/presentation/pages/notice_write_body_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_body_page.dart
@@ -291,7 +291,6 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
             bodyFocusNode: _koreanBodyFocusNode,
             titleController: _koreanTitleController,
             bodyController: _koreanBodyController,
-            isTranslateEnabled: false,
           ),
           BlocBuilder<AiBloc, AiState>(
             builder: (context, state) => Editor(
@@ -304,7 +303,7 @@ class _LayoutState extends State<_Layout> with SingleTickerProviderStateMixin {
                     const AnalyticsEvent.writeUseAiTranslation());
                 _translate();
               },
-              isTranslateEnabled: _englishBodyController
+              translateEnabled: _englishBodyController
                   .plainTextEditingValue.text
                   .trim()
                   .isEmpty,

--- a/lib/app/modules/notices/presentation/widgets/editor.dart
+++ b/lib/app/modules/notices/presentation/widgets/editor.dart
@@ -16,6 +16,7 @@ class Editor extends StatelessWidget {
     this.onTranslate,
     this.translating = false,
     this.titleDisabled = false,
+    required this.isTranslateEnabled,
   });
 
   final FocusNode titleFocusNode;
@@ -25,6 +26,7 @@ class Editor extends StatelessWidget {
   final VoidCallback? onTranslate;
   final bool translating;
   final bool titleDisabled;
+  final bool isTranslateEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +52,7 @@ class Editor extends StatelessWidget {
           child: Container(height: 1, color: Palette.grayBorder),
         ),
         const SizedBox(height: 10),
-        if (onTranslate != null)
+        if (isTranslateEnabled)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 18),
             child: Row(

--- a/lib/app/modules/notices/presentation/widgets/editor.dart
+++ b/lib/app/modules/notices/presentation/widgets/editor.dart
@@ -16,7 +16,7 @@ class Editor extends StatelessWidget {
     this.onTranslate,
     this.translating = false,
     this.titleDisabled = false,
-    required this.isTranslateEnabled,
+    this.translateEnabled = false,
   });
 
   final FocusNode titleFocusNode;
@@ -26,7 +26,7 @@ class Editor extends StatelessWidget {
   final VoidCallback? onTranslate;
   final bool translating;
   final bool titleDisabled;
-  final bool isTranslateEnabled;
+  final bool translateEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -52,7 +52,7 @@ class Editor extends StatelessWidget {
           child: Container(height: 1, color: Palette.grayBorder),
         ),
         const SizedBox(height: 10),
-        if (isTranslateEnabled)
+        if (translateEnabled)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 18),
             child: Row(


### PR DESCRIPTION
close #455
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 영어 편집기에서 번역 기능이 개선되어, 사용자 입력에 따라 번역 버튼의 가시성을 제어하는 `translateEnabled` 속성이 추가되었습니다.
	- 영어 본문 텍스트가 비어 있을 때만 번역 요청이 트리거되도록 개선되었습니다.
	- UI가 현재 영어 본문 텍스트 상태에 따라 번역 가능 여부를 반영하도록 업데이트되었습니다.

- **버그 수정**
	- 오류 상태 처리 및 오류 메시지를 토스트 알림으로 표시하는 기능이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->