### PR TITLE
fix: don't refresh even though token expired

### DIFF
--- a/lib/app/modules/core/data/repositories/fcm_messaging_repository.dart
+++ b/lib/app/modules/core/data/repositories/fcm_messaging_repository.dart
@@ -32,8 +32,10 @@ class FcmMessagingRepository implements MessagingRepository, LinkRepository {
     await instance.requestPermission(announcement: true, provisional: true);
     await _waitForIosToken();
 
-    final fcmToken = await FirebaseMessaging.instance.getToken();
-    _tokenSubject.add(fcmToken);
+    FirebaseMessaging.instance
+        .getToken()
+        .then(_tokenSubject.add)
+        .catchError((_) {});
     FirebaseMessaging.instance.onTokenRefresh.listen(_tokenSubject.add);
     await refresh();
     _tokenSubject.listen(refresh);

--- a/lib/app/modules/user/data/data_sources/remote/authorize_interceptor.dart
+++ b/lib/app/modules/user/data/data_sources/remote/authorize_interceptor.dart
@@ -39,11 +39,6 @@ class AuthorizeInterceptor extends Interceptor {
     RequestInterceptorHandler handler,
   ) async {
     if (options.retried) return handler.next(options);
-    if (_repository.tokenExpiration != null) {
-      if (DateTime.now().isAfter(_repository.tokenExpiration!)) {
-        await _refresh();
-      }
-    }
 
     try {
       await mutex.acquireRead();


### PR DESCRIPTION
close #456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- Firebase Cloud Messaging(Fcm) 토큰을 가져오는 과정의 오류 처리 방식을 개선하여 오류를 조용히 처리하도록 변경했습니다.
  
- **새로운 기능**
	- 요청 처리 로직에서 토큰 만료 확인을 제거하여 요청 처리 과정을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->