### PR TITLE
fix: ignore lang field of translation response

### DIFF
--- a/lib/app/modules/notices/data/models/translation_result_model.dart
+++ b/lib/app/modules/notices/data/models/translation_result_model.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:ziggle/app/modules/core/domain/enums/language.dart';
 
 part 'translation_result_model.freezed.dart';
 part 'translation_result_model.g.dart';
@@ -8,7 +7,6 @@ part 'translation_result_model.g.dart';
 class TranslationResultModel with _$TranslationResultModel {
   const factory TranslationResultModel({
     required String text,
-    required Language lang,
   }) = _TranslationResultModel;
 
   factory TranslationResultModel.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
lang field를 무시해서 자동 번역이 동작하게끔 합니다
fix #491 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- `TranslationResultModel` 클래스의 생성자에서 언어 필드가 제거되어 인스턴스 생성 시 언어 속성이 필수가 아닙니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->