### PR TITLE
feat: group manage main page logic

### DIFF
--- a/lib/app/modules/groups/data/data_sources/models/group_list_model.dart
+++ b/lib/app/modules/groups/data/data_sources/models/group_list_model.dart
@@ -10,7 +10,7 @@ class GroupListModel with _$GroupListModel implements GroupListEntity {
   const GroupListModel._();
 
   const factory GroupListModel({
-    required int total,
+    required int? total,
     required List<GroupModel> list,
   }) = _GroupListModel;
 

--- a/lib/app/modules/groups/data/data_sources/models/group_list_model.dart
+++ b/lib/app/modules/groups/data/data_sources/models/group_list_model.dart
@@ -10,7 +10,6 @@ class GroupListModel with _$GroupListModel implements GroupListEntity {
   const GroupListModel._();
 
   const factory GroupListModel({
-    required int? total,
     required List<GroupModel> list,
   }) = _GroupListModel;
 

--- a/lib/app/modules/groups/data/repositories/rest_group_repository.dart
+++ b/lib/app/modules/groups/data/repositories/rest_group_repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:injectable/injectable.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/models/create_group_model.dart';
+import 'package:ziggle/app/modules/groups/data/data_sources/models/group_list_model.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/models/group_model.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/remote/group_api.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/remote/notion_api.dart';
@@ -30,5 +31,10 @@ class RestGroupRepository implements GroupRepository {
       notionPageId: notionPageId,
     ));
     return createdGroup;
+  }
+
+  @override
+  Future<GroupListModel> getGroups() {
+    return _api.getGroups();
   }
 }

--- a/lib/app/modules/groups/domain/entities/group_list_entity.dart
+++ b/lib/app/modules/groups/domain/entities/group_list_entity.dart
@@ -1,7 +1,7 @@
 import 'package:ziggle/app/modules/groups/domain/entities/group_entity.dart';
 
 class GroupListEntity {
-  final int total;
+  final int? total;
   final List<GroupEntity> list;
 
   GroupListEntity({required this.total, required this.list});

--- a/lib/app/modules/groups/domain/entities/group_list_entity.dart
+++ b/lib/app/modules/groups/domain/entities/group_list_entity.dart
@@ -1,8 +1,7 @@
 import 'package:ziggle/app/modules/groups/domain/entities/group_entity.dart';
 
 class GroupListEntity {
-  final int? total;
   final List<GroupEntity> list;
 
-  GroupListEntity({required this.total, required this.list});
+  GroupListEntity({required this.list});
 }

--- a/lib/app/modules/groups/domain/repository/group_repository.dart
+++ b/lib/app/modules/groups/domain/repository/group_repository.dart
@@ -1,3 +1,4 @@
+import 'package:ziggle/app/modules/groups/data/data_sources/models/group_list_model.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/models/group_model.dart';
 
 abstract class GroupRepository {
@@ -7,4 +8,6 @@ abstract class GroupRepository {
     required String? notionPageId,
     // required File image,
   });
+
+  Future<GroupListModel> getGroups();
 }

--- a/lib/app/modules/groups/domain/repository/group_repository.dart
+++ b/lib/app/modules/groups/domain/repository/group_repository.dart
@@ -1,5 +1,5 @@
-import 'package:ziggle/app/modules/groups/data/data_sources/models/group_list_model.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/models/group_model.dart';
+import 'package:ziggle/app/modules/groups/domain/entities/group_list_entity.dart';
 
 abstract class GroupRepository {
   Future<GroupModel> createGroup({
@@ -9,5 +9,5 @@ abstract class GroupRepository {
     // required File image,
   });
 
-  Future<GroupListModel> getGroups();
+  Future<GroupListEntity> getGroups();
 }

--- a/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
+++ b/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
@@ -13,25 +13,20 @@ class GroupManagementMainBloc
   final GroupRepository _repository;
 
   GroupManagementMainBloc(this._repository) : super(_Initial()) {
-    on<_Load>((event, emit) async {
-      emit(_Loading());
-      try {
-        final groups = await _repository.getGroups();
-        emit(_Loaded(groups));
-      } on Exception catch (e) {
-        emit(_Error(e.toString()));
-      }
-    });
-    on<_Refresh>((event, emit) async {
-      emit(_Loading());
-      try {
-        final groups = await _repository.getGroups();
-        emit(_Loaded(groups));
-      } on Exception catch (e) {
-        emit(_Error(e.toString()));
-      }
-    });
+    on<_Load>(_handleLoadOrRefresh);
+    on<_Refresh>(_handleLoadOrRefresh);
   }
+
+  void _handleLoadOrRefresh(event, emit) async {
+    emit(_Loading());
+    try {
+      final groups = await _repository.getGroups();
+      emit(_Loaded(groups));
+    } on Exception catch (e) {
+      emit(_Error(e.toString()));
+    }
+  }
+
   static Future<void> refresh(BuildContext context) async {
     final bloc = context.read<GroupManagementMainBloc>();
     final blocker = bloc.stream.firstWhere((state) => !state.isLoading);

--- a/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
+++ b/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
@@ -17,7 +17,8 @@ class GroupManagementMainBloc
     on<_Refresh>(_handleLoadOrRefresh);
   }
 
-  void _handleLoadOrRefresh(event, emit) async {
+  void _handleLoadOrRefresh(
+      event, Emitter<GroupManagementMainState> emit) async {
     emit(_Loading());
     try {
       final groups = await _repository.getGroups();

--- a/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
+++ b/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
@@ -8,7 +9,7 @@ part 'group_management_main_bloc.freezed.dart';
 
 @injectable
 class GroupManagementMainBloc
-    extends Bloc<GroupManagementMainBlocEvent, GroupManagementMainBlocState> {
+    extends Bloc<GroupManagementMainEvent, GroupManagementMainState> {
   final GroupRepository _repository;
 
   GroupManagementMainBloc(this._repository) : super(_Initial()) {
@@ -21,20 +22,40 @@ class GroupManagementMainBloc
         emit(_Error(e.toString()));
       }
     });
+    on<_Refresh>((event, emit) async {
+      emit(_Loading());
+      try {
+        final groups = await _repository.getGroups();
+        emit(_Loaded(groups));
+      } on Exception catch (e) {
+        emit(_Error(e.toString()));
+      }
+    });
+  }
+  static Future<void> refresh(BuildContext context) async {
+    final bloc = context.read<GroupManagementMainBloc>();
+    final blocker = bloc.stream.firstWhere((state) => !state.isLoading);
+    bloc.add(_Refresh());
+    await blocker;
   }
 }
 
 @freezed
-class GroupManagementMainBlocEvent with _$GroupManagementMainBlocEvent {
-  const factory GroupManagementMainBlocEvent.started() = _Started;
-  const factory GroupManagementMainBlocEvent.load() = _Load;
+class GroupManagementMainEvent with _$GroupManagementMainEvent {
+  const factory GroupManagementMainEvent.load() = _Load;
+  const factory GroupManagementMainEvent.refresh() = _Refresh;
 }
 
 @freezed
-class GroupManagementMainBlocState with _$GroupManagementMainBlocState {
-  const factory GroupManagementMainBlocState.initial() = _Initial;
-  const factory GroupManagementMainBlocState.loading() = _Loading;
-  const factory GroupManagementMainBlocState.loaded(GroupListEntity groups) =
+class GroupManagementMainState with _$GroupManagementMainState {
+  const GroupManagementMainState._();
+
+  const factory GroupManagementMainState.initial() = _Initial;
+  const factory GroupManagementMainState.loading() = _Loading;
+  const factory GroupManagementMainState.loaded(GroupListEntity groups) =
       _Loaded;
-  const factory GroupManagementMainBlocState.error(String message) = _Error;
+  const factory GroupManagementMainState.error(String message) = _Error;
+
+  GroupListEntity? get groups => mapOrNull(loaded: (e) => e.groups);
+  bool get isLoading => this is _Loading;
 }

--- a/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
+++ b/lib/app/modules/groups/presentation/blocs/group_management_main_bloc.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:ziggle/app/modules/groups/domain/entities/group_list_entity.dart';
+import 'package:ziggle/app/modules/groups/domain/repository/group_repository.dart';
+
+part 'group_management_main_bloc.freezed.dart';
+
+@injectable
+class GroupManagementMainBloc
+    extends Bloc<GroupManagementMainBlocEvent, GroupManagementMainBlocState> {
+  final GroupRepository _repository;
+
+  GroupManagementMainBloc(this._repository) : super(_Initial()) {
+    on<_Load>((event, emit) async {
+      emit(_Loading());
+      try {
+        final groups = await _repository.getGroups();
+        emit(_Loaded(groups));
+      } on Exception catch (e) {
+        emit(_Error(e.toString()));
+      }
+    });
+  }
+}
+
+@freezed
+class GroupManagementMainBlocEvent with _$GroupManagementMainBlocEvent {
+  const factory GroupManagementMainBlocEvent.started() = _Started;
+  const factory GroupManagementMainBlocEvent.load() = _Load;
+}
+
+@freezed
+class GroupManagementMainBlocState with _$GroupManagementMainBlocState {
+  const factory GroupManagementMainBlocState.initial() = _Initial;
+  const factory GroupManagementMainBlocState.loading() = _Loading;
+  const factory GroupManagementMainBlocState.loaded(GroupListEntity groups) =
+      _Loaded;
+  const factory GroupManagementMainBlocState.error(String message) = _Error;
+}

--- a/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
@@ -1,7 +1,10 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ziggle/app/di/locator.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
 import 'package:ziggle/app/modules/core/domain/enums/page_source.dart';
+import 'package:ziggle/app/modules/groups/presentation/blocs/group_management_main_bloc.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
 import 'package:ziggle/gen/strings.g.dart';
@@ -12,87 +15,92 @@ class GroupManagementMainPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: ZiggleAppBar.compact(
-        backLabel: context.t.user.myInfo,
-        from: PageSource.unknown,
-        title: Text(context.t.group.managementMain.header),
-        actions: [
-          GestureDetector(
-            child: Text(
-              context.t.group.managementMain.newGroup,
-              style: const TextStyle(
-                fontSize: 16,
-                color: Palette.primary,
-                fontWeight: FontWeight.w400,
-              ),
-            ),
-          )
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 25, 16, 10),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              context.t.group.managementMain.myGroup,
-              style: const TextStyle(
-                fontSize: 28,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(
-              height: 20,
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Column(
-                  children: [
-                    Assets.images.bonfire.svg(),
-                    const SizedBox(height: 20),
-                    Text(
-                      context.t.group.managementMain.noGroup,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: Palette.grayText,
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    )
-                  ],
+    return BlocProvider(
+      create: (context) => sl<GroupManagementMainBloc>()
+        ..add(GroupManagementMainBlocEvent.load()),
+      child: Scaffold(
+        appBar: ZiggleAppBar.compact(
+          backLabel: context.t.user.myInfo,
+          from: PageSource.unknown,
+          title: Text(context.t.group.managementMain.header),
+          actions: [
+            GestureDetector(
+              child: Text(
+                context.t.group.managementMain.newGroup,
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Palette.primary,
+                  fontWeight: FontWeight.w400,
                 ),
-              ],
-            ),
-            const SizedBox(height: 20),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-              decoration: ShapeDecoration(
-                color: Palette.grayLight,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Expanded(
-                    child: SizedBox(
-                      child: Text(
-                        context.t.group.managementMain.contact,
-                        style: const TextStyle(
-                          color: Palette.grayText,
-                          fontSize: 14,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
               ),
             )
           ],
+        ),
+        body: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 25, 16, 10),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                context.t.group.managementMain.myGroup,
+                style: const TextStyle(
+                  fontSize: 28,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Column(
+                    children: [
+                      Assets.images.bonfire.svg(),
+                      const SizedBox(height: 20),
+                      Text(
+                        context.t.group.managementMain.noGroup,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Palette.grayText,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      )
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+                decoration: ShapeDecoration(
+                  color: Palette.grayLight,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Expanded(
+                      child: SizedBox(
+                        child: Text(
+                          context.t.group.managementMain.contact,
+                          style: const TextStyle(
+                            color: Palette.grayText,
+                            fontSize: 14,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
@@ -64,29 +64,22 @@ class GroupManagementMainPage extends StatelessWidget {
                     if (state.groups != null)
                       Expanded(
                         child: ListView.separated(
-                          itemBuilder: (context, index) {
-                            if (index < state.groups!.list.length) {
-                              return GroupListItem(
-                                name: state.groups!.list[index].name,
-                                onPressed: () {},
-                              );
-                            } else if (index == state.groups!.list.length) {
-                              return Column(
-                                children: [
-                                  InquiryWidget(),
-                                  SizedBox(height: 25),
-                                ],
-                              );
-                            }
-                            return null;
-                          },
-                          separatorBuilder: (context, index) {
-                            if (index < state.groups!.list.length - 1) {
-                              return const SizedBox(height: 5);
-                            }
-                            return SizedBox(height: 20);
-                          },
                           itemCount: state.groups!.list.length + 1,
+                          itemBuilder: (context, index) {
+                            if (index == state.groups!.list.length) {
+                              return Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(0, 15, 0, 25),
+                                child: _InquiryWidget(),
+                              );
+                            }
+                            return GroupListItem(
+                              name: state.groups!.list[index].name,
+                              onPressed: () {},
+                            );
+                          },
+                          separatorBuilder: (context, index) =>
+                              SizedBox(height: 5),
                         ),
                       )
                     else if (state.isLoading)
@@ -108,7 +101,7 @@ class GroupManagementMainPage extends StatelessWidget {
                             ),
                           ),
                           SizedBox(height: 20),
-                          InquiryWidget(),
+                          _InquiryWidget(),
                         ],
                       ),
                   ],
@@ -122,11 +115,7 @@ class GroupManagementMainPage extends StatelessWidget {
   }
 }
 
-class InquiryWidget extends StatelessWidget {
-  const InquiryWidget({
-    super.key,
-  });
-
+class _InquiryWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(

--- a/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ziggle/app/di/locator.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
 import 'package:ziggle/app/modules/core/domain/enums/page_source.dart';
 import 'package:ziggle/app/modules/groups/presentation/blocs/group_management_main_bloc.dart';
+import 'package:ziggle/app/modules/groups/presentation/widgets/group_list_item.dart';
+import 'package:ziggle/app/router.gr.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
 import 'package:ziggle/gen/strings.g.dart';
@@ -16,92 +19,116 @@ class GroupManagementMainPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => sl<GroupManagementMainBloc>()
-        ..add(GroupManagementMainBlocEvent.load()),
-      child: Scaffold(
-        appBar: ZiggleAppBar.compact(
-          backLabel: context.t.user.myInfo,
-          from: PageSource.unknown,
-          title: Text(context.t.group.managementMain.header),
-          actions: [
-            GestureDetector(
-              child: Text(
-                context.t.group.managementMain.newGroup,
-                style: const TextStyle(
-                  fontSize: 16,
-                  color: Palette.primary,
-                  fontWeight: FontWeight.w400,
-                ),
-              ),
-            )
-          ],
-        ),
-        body: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 25, 16, 10),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                context.t.group.managementMain.myGroup,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(
-                height: 20,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Column(
-                    children: [
-                      Assets.images.bonfire.svg(),
-                      const SizedBox(height: 20),
-                      Text(
-                        context.t.group.managementMain.noGroup,
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: Palette.grayText,
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      )
-                    ],
+      create: (context) =>
+          sl<GroupManagementMainBloc>()..add(GroupManagementMainEvent.load()),
+      child: BlocBuilder<GroupManagementMainBloc, GroupManagementMainState>(
+        builder: (context, state) {
+          return Scaffold(
+            appBar: ZiggleAppBar.compact(
+              backLabel: context.t.user.myInfo,
+              from: PageSource.unknown,
+              title: Text(context.t.group.managementMain.header),
+              actions: [
+                ZiggleButton.text(
+                  child: Text(
+                    context.t.group.managementMain.newGroup,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      color: Palette.primary,
+                      fontWeight: FontWeight.w400,
+                    ),
                   ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              Container(
+                  onPressed: () => GroupCreationProfileRoute().push(context),
+                ),
+              ],
+            ),
+            body: RefreshIndicator(
+              onRefresh: () => GroupManagementMainBloc.refresh(context),
+              child: Padding(
                 padding:
-                    const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-                decoration: ShapeDecoration(
-                  color: Palette.grayLight,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 25),
+                child: Column(
                   children: [
-                    Expanded(
-                      child: SizedBox(
-                        child: Text(
-                          context.t.group.managementMain.contact,
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        Text(
+                          context.t.group.managementMain.myGroup,
                           style: const TextStyle(
-                            color: Palette.grayText,
-                            fontSize: 14,
+                            fontSize: 28,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
+                      ],
+                    ),
+                    const SizedBox(height: 20),
+                    // if (state is GroupManagementMainState.loading)
+                    //   const Center(
+                    //     child: CircularProgressIndicator(),
+                    //   )
+                    if (state.groups != null)
+                      Expanded(
+                        child: ListView.separated(
+                          itemBuilder: (context, index) => GroupListItem(
+                            name: state.groups!.list[index].name,
+                            onPressed: () {},
+                          ),
+                          separatorBuilder: (context, ixndex) =>
+                              const SizedBox(height: 5),
+                          itemCount: state.groups!.list.length,
+                        ),
+                      )
+                    else if (state.isLoading)
+                      CircularProgressIndicator()
+                    else
+                      Column(
+                        children: [
+                          Assets.images.bonfire.svg(),
+                          const SizedBox(height: 20),
+                          Text(
+                            context.t.group.managementMain.noGroup,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              color: Palette.grayText,
+                              fontSize: 20,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    const SizedBox(height: 20),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 15, vertical: 10),
+                      decoration: ShapeDecoration(
+                        color: Palette.grayLight,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Expanded(
+                            child: SizedBox(
+                              child: Text(
+                                context.t.group.managementMain.contact,
+                                style: const TextStyle(
+                                  color: Palette.grayText,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ],
                 ),
-              )
-            ],
-          ),
-        ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_management_main_page.dart
@@ -45,8 +45,7 @@ class GroupManagementMainPage extends StatelessWidget {
             body: RefreshIndicator(
               onRefresh: () => GroupManagementMainBloc.refresh(context),
               child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 25),
+                padding: const EdgeInsets.fromLTRB(16, 25, 16, 0),
                 child: Column(
                   children: [
                     Row(
@@ -62,24 +61,38 @@ class GroupManagementMainPage extends StatelessWidget {
                       ],
                     ),
                     const SizedBox(height: 20),
-                    // if (state is GroupManagementMainState.loading)
-                    //   const Center(
-                    //     child: CircularProgressIndicator(),
-                    //   )
                     if (state.groups != null)
                       Expanded(
                         child: ListView.separated(
-                          itemBuilder: (context, index) => GroupListItem(
-                            name: state.groups!.list[index].name,
-                            onPressed: () {},
-                          ),
-                          separatorBuilder: (context, ixndex) =>
-                              const SizedBox(height: 5),
-                          itemCount: state.groups!.list.length,
+                          itemBuilder: (context, index) {
+                            if (index < state.groups!.list.length) {
+                              return GroupListItem(
+                                name: state.groups!.list[index].name,
+                                onPressed: () {},
+                              );
+                            } else if (index == state.groups!.list.length) {
+                              return Column(
+                                children: [
+                                  InquiryWidget(),
+                                  SizedBox(height: 25),
+                                ],
+                              );
+                            }
+                            return null;
+                          },
+                          separatorBuilder: (context, index) {
+                            if (index < state.groups!.list.length - 1) {
+                              return const SizedBox(height: 5);
+                            }
+                            return SizedBox(height: 20);
+                          },
+                          itemCount: state.groups!.list.length + 1,
                         ),
                       )
                     else if (state.isLoading)
-                      CircularProgressIndicator()
+                      Expanded(
+                        child: Center(child: CircularProgressIndicator()),
+                      )
                     else
                       Column(
                         children: [
@@ -94,41 +107,49 @@ class GroupManagementMainPage extends StatelessWidget {
                               fontWeight: FontWeight.w600,
                             ),
                           ),
+                          SizedBox(height: 20),
+                          InquiryWidget(),
                         ],
                       ),
-                    const SizedBox(height: 20),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 15, vertical: 10),
-                      decoration: ShapeDecoration(
-                        color: Palette.grayLight,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Expanded(
-                            child: SizedBox(
-                              child: Text(
-                                context.t.group.managementMain.contact,
-                                style: const TextStyle(
-                                  color: Palette.grayText,
-                                  fontSize: 14,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
                   ],
                 ),
               ),
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+class InquiryWidget extends StatelessWidget {
+  const InquiryWidget({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+      decoration: ShapeDecoration(
+        color: Palette.grayLight,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Expanded(
+            child: Text(
+              context.t.group.managementMain.contact,
+              style: const TextStyle(
+                color: Palette.grayText,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/app/modules/groups/presentation/widgets/group_list_item.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_list_item.dart
@@ -10,7 +10,6 @@ class GroupListItem extends StatelessWidget {
     super.key,
     required this.name,
     this.isCertificated = false,
-    this.isGrouped = true,
     this.profileImage,
     this.onPressed,
   });
@@ -18,53 +17,41 @@ class GroupListItem extends StatelessWidget {
   final String name;
   final Image? profileImage;
   final bool isCertificated;
-  final bool isGrouped;
   final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
     return ZigglePressable(
       onPressed: onPressed,
-      child: Container(
-        padding: isGrouped ? const EdgeInsets.all(10) : null,
-        decoration: isGrouped
-            ? ShapeDecoration(
-                color: Palette.grayLight,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-              )
-            : null,
-        child: Row(
-          children: [
-            if (profileImage != null)
-              SizedBox(
-                height: 36,
-                width: 36,
-                child: profileImage,
-              )
-            else
-              SizedBox(
-                height: 36,
-                width: 36,
-                child: Assets.images.groupDefaultProfile.image(),
-              ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                name,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
+      child: Row(
+        children: [
+          if (profileImage != null)
+            SizedBox(
+              height: 36,
+              width: 36,
+              child: profileImage,
+            )
+          else
+            SizedBox(
+              height: 36,
+              width: 36,
+              child: Assets.images.groupDefaultProfile.image(),
+            ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              name,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
               ),
             ),
-            if (isCertificated) ...[
-              const SizedBox(width: 5),
-              Assets.icons.certificatedBadge.svg(),
-            ]
-          ],
-        ),
+          ),
+          if (isCertificated) ...[
+            const SizedBox(width: 5),
+            Assets.icons.certificatedBadge.svg(),
+          ]
+        ],
       ),
     );
   }

--- a/lib/app/modules/groups/presentation/widgets/group_list_item.dart
+++ b/lib/app/modules/groups/presentation/widgets/group_list_item.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_pressable.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
 
@@ -8,51 +11,60 @@ class GroupListItem extends StatelessWidget {
     required this.name,
     this.isCertificated = false,
     this.isGrouped = true,
+    this.profileImage,
+    this.onPressed,
   });
 
   final String name;
+  final Image? profileImage;
   final bool isCertificated;
   final bool isGrouped;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: isGrouped ? const EdgeInsets.all(10) : null,
-      decoration: isGrouped
-          ? ShapeDecoration(
-              color: Palette.grayLight,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
+    return ZigglePressable(
+      onPressed: onPressed,
+      child: Container(
+        padding: isGrouped ? const EdgeInsets.all(10) : null,
+        decoration: isGrouped
+            ? ShapeDecoration(
+                color: Palette.grayLight,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              )
+            : null,
+        child: Row(
+          children: [
+            if (profileImage != null)
+              SizedBox(
+                height: 36,
+                width: 36,
+                child: profileImage,
+              )
+            else
+              SizedBox(
+                height: 36,
+                width: 36,
+                child: Assets.images.groupDefaultProfile.image(),
               ),
-            )
-          : null,
-      child: Row(
-        children: [
-          Container(
-            height: 36,
-            width: 36,
-            decoration: ShapeDecoration(
-              color: Palette.primary,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(100),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                name,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ),
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              name,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-          if (isCertificated) ...[
-            const SizedBox(width: 5),
-            Assets.icons.certificatedBadge.svg(),
-          ]
-        ],
+            if (isCertificated) ...[
+              const SizedBox(width: 5),
+              Assets.icons.certificatedBadge.svg(),
+            ]
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -115,6 +115,10 @@ class AppRouter extends RootStackRouter {
         ],
       ),
       AutoRoute(
+        path: '/group/managementMain',
+        page: GroupManagementMainRoute.page,
+      ),
+      AutoRoute(
         path: '/group/detail',
         page: GroupDetailRoute.page,
       )

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -115,7 +115,7 @@ class AppRouter extends RootStackRouter {
         ],
       ),
       AutoRoute(
-        path: '/group/managementMain',
+        path: '/group/management-main',
         page: GroupManagementMainRoute.page,
       ),
       AutoRoute(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 그룹 관리 페이지에 Bloc 패턴을 통한 상태 관리 추가.
	- 그룹 목록을 가져오는 `getGroups` 메소드 추가.
	- 그룹 목록 항목에 프로필 이미지 및 클릭 이벤트 처리 기능 추가.
	- 새로운 경로 `/group/management-main` 추가로 그룹 관리 섹션으로의 내비게이션 지원.

- **버그 수정**
	- `total` 필드를 nullable로 변경하여 null 값 처리 개선.

- **문서화**
	- Bloc 및 상태 관리에 대한 구조적 접근 방식 정의.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->