### PR TITLE
feat: all region of consent item is clickable

### DIFF
--- a/lib/app/modules/common/presentation/widgets/ziggle_checkbox.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_checkbox.dart
@@ -1,39 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:ziggle/app/values/palette.dart';
 
-class ZiggleCheckbox extends StatefulWidget {
+class ZiggleCheckbox extends StatelessWidget {
   const ZiggleCheckbox({
     super.key,
+    required this.isChecked,
     required this.onToggle,
-    this.initialState = false,
     this.loading = false,
     this.disabled = false,
   });
 
+  final bool isChecked;
   final ValueChanged<bool> onToggle;
-  final bool initialState;
   final bool loading;
   final bool disabled;
 
-  @override
-  State<ZiggleCheckbox> createState() => _ZiggleCheckboxState();
-}
-
-class _ZiggleCheckboxState extends State<ZiggleCheckbox> {
-  bool _checked = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _checked = widget.initialState;
-  }
-
   void _handleCheck() {
-    if (widget.disabled || widget.loading) return;
-    setState(() {
-      _checked = !_checked;
-    });
-    widget.onToggle(_checked);
+    if (disabled || loading) return;
+    onToggle(!isChecked);
   }
 
   @override
@@ -44,16 +28,16 @@ class _ZiggleCheckboxState extends State<ZiggleCheckbox> {
         width: 24.0,
         height: 24.0,
         decoration: BoxDecoration(
-          color: _checked ? Palette.primary : Palette.white,
+          color: isChecked ? Palette.primary : Palette.white,
           borderRadius: BorderRadius.circular(7.0),
           border: Border.all(
-            color: _checked ? Palette.primary : Palette.gray,
+            color: isChecked ? Palette.primary : Palette.gray,
             width: 1.5,
           ),
         ),
         child: Center(
           child: AnimatedOpacity(
-            opacity: _checked ? 1.0 : 0.0,
+            opacity: isChecked ? 1.0 : 0.0,
             duration: const Duration(milliseconds: 100),
             child: const Icon(
               Icons.check,

--- a/lib/app/modules/notices/presentation/widgets/consent_item.dart
+++ b/lib/app/modules/notices/presentation/widgets/consent_item.dart
@@ -18,45 +18,49 @@ class ConsentItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedContainer(
-      duration: Durations.medium1,
-      decoration: ShapeDecoration(
-        color: isChecked ? Palette.primaryLight : Palette.grayLight,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(15),
-        ),
-      ),
-      padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 14),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ZiggleCheckbox(
-            onToggle: onChanged,
+    return GestureDetector(
+      onTap: () => onChanged(!isChecked),
+      child: AnimatedContainer(
+        duration: Durations.medium1,
+        decoration: ShapeDecoration(
+          color: isChecked ? Palette.primaryLight : Palette.grayLight,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(15),
           ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  title,
-                  style: const TextStyle(
-                    color: Palette.black,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                    letterSpacing: -0.45,
-                  ),
-                ),
-                Text(
-                  description,
-                )
-              ],
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 14),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ZiggleCheckbox(
+              isChecked: isChecked,
+              onToggle: onChanged,
             ),
-          )
-        ],
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: Palette.black,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: -0.45,
+                    ),
+                  ),
+                  Text(
+                    description,
+                  )
+                ],
+              ),
+            )
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
… property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `ZiggleCheckbox` 위젯이 외부 상태 관리를 사용하도록 변경되어 체크박스의 상태를 외부에서 관리할 수 있게 되었습니다.
	- `ConsentItem` 위젯에 `GestureDetector`가 추가되어 사용자가 전체 컨테이너를 탭하여 체크박스 상태를 전환할 수 있는 사용자 상호작용이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->