### PR TITLE
feat: group creation with image

### DIFF
--- a/lib/app/modules/groups/data/data_sources/remote/group_api.dart
+++ b/lib/app/modules/groups/data/data_sources/remote/group_api.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/retrofit.dart';
@@ -42,11 +44,12 @@ abstract class GroupApi {
   @GET('{name}/exist')
   Future<String> checkGroupExistence(@Path('name') String name);
 
-  // @POST('{uuid}/image')
-  // Future<void> uploadImage(
-  //   @Path('uuid') String uuid,
-  //   @Part() File? image,
-  // );
+  @POST('{uuid}/image')
+  @MultiPart()
+  Future<void> uploadImage(
+    @Path('uuid') String uuid,
+    @Part(name: 'file') File image,
+  );
 
   @POST('{uuid}/invite')
   Future<Map<String, String>> createInviteCode(@Path('uuid') String uuid);

--- a/lib/app/modules/groups/data/repositories/rest_group_repository.dart
+++ b/lib/app/modules/groups/data/repositories/rest_group_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:injectable/injectable.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/models/create_group_model.dart';
@@ -21,15 +22,17 @@ class RestGroupRepository implements GroupRepository {
   @override
   Future<GroupModel> createGroup({
     required String name,
+    File? image,
     required String description,
     String? notionPageId,
-    File? image,
   }) async {
     final createdGroup = await _api.createGroup(CreateGroupModel(
       name: name,
       description: description,
       notionPageId: notionPageId,
     ));
+
+    if (image != null) await _api.uploadImage(createdGroup.uuid, image);
     return createdGroup;
   }
 

--- a/lib/app/modules/groups/data/repositories/rest_group_repository.dart
+++ b/lib/app/modules/groups/data/repositories/rest_group_repository.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:injectable/injectable.dart';
 import 'package:ziggle/app/modules/groups/data/data_sources/models/create_group_model.dart';

--- a/lib/app/modules/groups/domain/entities/group_create_draft_entity.dart
+++ b/lib/app/modules/groups/domain/entities/group_create_draft_entity.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'group_create_draft_entity.freezed.dart';
@@ -6,6 +8,7 @@ part 'group_create_draft_entity.freezed.dart';
 class GroupCreateDraftEntity with _$GroupCreateDraftEntity {
   const factory GroupCreateDraftEntity({
     @Default('') String name,
+    File? image,
     @Default('') String description,
     String? notionPageId,
   }) = _GroupCreateDraftEntity;

--- a/lib/app/modules/groups/domain/repository/group_repository.dart
+++ b/lib/app/modules/groups/domain/repository/group_repository.dart
@@ -1,12 +1,14 @@
+import 'dart:io';
+
 import 'package:ziggle/app/modules/groups/data/data_sources/models/group_model.dart';
 import 'package:ziggle/app/modules/groups/domain/entities/group_list_entity.dart';
 
 abstract class GroupRepository {
   Future<GroupModel> createGroup({
     required String name,
+    File? image,
     required String description,
-    required String? notionPageId,
-    // required File image,
+    String? notionPageId,
   });
 
   Future<GroupListEntity> getGroups();

--- a/lib/app/modules/groups/presentation/blocs/group_create_bloc.dart
+++ b/lib/app/modules/groups/presentation/blocs/group_create_bloc.dart
@@ -13,8 +13,11 @@ class GroupCreateBloc extends Bloc<GroupCreateEvent, GroupCreateState> {
   final GroupRepository _repository;
 
   GroupCreateBloc(this._repository) : super(const _Draft()) {
-    on<_SetName>(
-        (event, emit) => emit(_Draft(state.draft.copyWith(name: event.name))));
+    on<_SetName>((event, emit) => emit(_Draft(state.draft
+        .copyWith(name: event.name, description: state.draft.description))));
+    on<_SetImage>(
+      (event, emit) => emit(_Draft(state.draft.copyWith(image: event.image))),
+    );
     on<_SetDescription>((event, emit) => emit(_Draft(state.draft.copyWith(
           description: event.description,
         ))));
@@ -25,6 +28,7 @@ class GroupCreateBloc extends Bloc<GroupCreateEvent, GroupCreateState> {
       try {
         _repository.createGroup(
           name: state.draft.name,
+          image: state.draft.image,
           description: state.draft.description,
           notionPageId: state.draft.notionPageId,
         );
@@ -39,7 +43,7 @@ class GroupCreateBloc extends Bloc<GroupCreateEvent, GroupCreateState> {
 @freezed
 class GroupCreateEvent with _$GroupCreateEvent {
   const factory GroupCreateEvent.setName(String name) = _SetName;
-  const factory GroupCreateEvent.setImage(File? images) = _SetImage;
+  const factory GroupCreateEvent.setImage(File? image) = _SetImage;
   const factory GroupCreateEvent.setDescription(String description) =
       _SetDescription;
   const factory GroupCreateEvent.setNotionPageId(String notionPageId) =

--- a/lib/app/modules/groups/presentation/pages/group_creation_notion_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_creation_notion_page.dart
@@ -100,6 +100,7 @@ class _LayoutState extends State<_Layout> {
             Expanded(
               child: ZiggleButton.cta(
                 outlined: true,
+                onPressed: () => context.maybePop(),
                 child: Text(context.t.common.back),
               ),
             ),

--- a/lib/app/modules/groups/presentation/pages/group_creation_profile_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_creation_profile_page.dart
@@ -81,6 +81,11 @@ class _LayoutState extends State<_Layout> {
             context
                 .read<GroupCreateBloc>()
                 .add(GroupCreateEvent.setName(_name));
+            if (_image != null) {
+              context
+                  .read<GroupCreateBloc>()
+                  .add(GroupCreateEvent.setImage(_image));
+            }
             const GroupCreationIntroduceRoute().push(context);
           },
           disabled: _name.isEmpty,


### PR DESCRIPTION
+ fixe back button in group creation notion page
close #507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 그룹 생성 시 이미지를 업로드할 수 있는 기능 추가.
	- 그룹 생성 화면에서 이미지 선택 후 그룹 생성 이벤트에 이미지 포함 가능.

- **버그 수정**
	- 그룹 생성 시 설명 필드가 변경되지 않도록 개선.

- **UI 개선**
	- "뒤로" 버튼 클릭 시 이전 화면으로 돌아가는 기능 추가.
	- 그룹 생성 프로필 페이지에서 이미지 선택 시 해당 이미지를 이벤트에 포함하도록 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->