### PR TITLE
fix: get initial app link error

### DIFF
--- a/lib/app/di/module.dart
+++ b/lib/app/di/module.dart
@@ -1,3 +1,4 @@
+import 'package:app_links/app_links.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -21,6 +22,9 @@ abstract class AppModule {
       storage: FileStorage("$appDocPath/.cookies/"),
     );
   }
+
+  @singleton
+  AppLinks get appLinks => AppLinks();
 
   @singleton
   CookieManager getCookieManager(CookieJar cookieJar) =>

--- a/lib/app/di/module.dart
+++ b/lib/app/di/module.dart
@@ -1,4 +1,3 @@
-import 'package:app_links/app_links.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -22,9 +21,6 @@ abstract class AppModule {
       storage: FileStorage("$appDocPath/.cookies/"),
     );
   }
-
-  @singleton
-  AppLinks get appLinks => AppLinks();
 
   @singleton
   CookieManager getCookieManager(CookieJar cookieJar) =>

--- a/lib/app/modules/core/data/repositories/app_links_link_repository.dart
+++ b/lib/app/modules/core/data/repositories/app_links_link_repository.dart
@@ -6,20 +6,21 @@ import 'package:rxdart/rxdart.dart';
 
 import '../../domain/repositories/link_repository.dart';
 
-@singleton
+@Singleton(order: -10)
 class AppLinksLinkRepository implements LinkRepository {
   final _linkSubject = BehaviorSubject<String>();
   late final StreamSubscription<String?> _subscription;
-  final AppLinks appLinks;
-
-  AppLinksLinkRepository(this.appLinks);
+  final appLinks = AppLinks();
 
   @PostConstruct(preResolve: true)
   Future<void> init() async {
     final initialLink =
-        await appLinks.getInitialLinkString().catchError((_) => null);
-    if (initialLink != null) _linkSubject.add(initialLink);
-    _subscription = appLinks.stringLinkStream.listen(_linkSubject.add);
+        (await appLinks.getInitialLink().catchError((_) => null)) ??
+            (await appLinks.getLatestLink().catchError((_) => null));
+    if (initialLink != null) _linkSubject.add(initialLink.toString());
+    _subscription = appLinks.uriLinkStream
+        .map((l) => l.toString())
+        .listen(_linkSubject.add);
   }
 
   @disposeMethod

--- a/lib/app/modules/core/data/repositories/app_links_link_repository.dart
+++ b/lib/app/modules/core/data/repositories/app_links_link_repository.dart
@@ -10,7 +10,9 @@ import '../../domain/repositories/link_repository.dart';
 class AppLinksLinkRepository implements LinkRepository {
   final _linkSubject = BehaviorSubject<String>();
   late final StreamSubscription<String?> _subscription;
-  final appLinks = AppLinks();
+  final AppLinks appLinks;
+
+  AppLinksLinkRepository(this.appLinks);
 
   @PostConstruct(preResolve: true)
   Future<void> init() async {

--- a/lib/app/modules/core/presentation/bloc/link_bloc.dart
+++ b/lib/app/modules/core/presentation/bloc/link_bloc.dart
@@ -13,7 +13,7 @@ class LinkBloc extends Bloc<LinkEvent, LinkState> {
     on<_Init>((event, emit) {
       emit(const LinkState.loading());
       return emit.forEach(
-        _repository.getLinkStream().expand((event) => [event, null]),
+        _repository.getLinkStream().expand((event) => [null, event]),
         onData: (state) => state != null ? _Loaded(state) : const _Initial(),
         onError: (error, _) => const _Error(),
       );

--- a/lib/app/modules/splash/presentation/pages/splash_page.dart
+++ b/lib/app/modules/splash/presentation/pages/splash_page.dart
@@ -28,10 +28,12 @@ class _SplashPageState extends State<SplashPage> {
           final linkData =
               context.read<LinkBloc>().state.whenOrNull(loaded: (link) => link);
           if (linkData != null) {
-            context.router
-              ..replaceAll([const FeedRoute()])
-              ..replaceNamed(linkData);
-            return;
+            try {
+              context.router
+                ..replaceAll([const FeedRoute()])
+                ..replaceNamed(linkData);
+              return;
+            } catch (_) {}
           }
           context.router.replaceAll([const FeedRoute()]);
         },

--- a/lib/app/modules/splash/presentation/pages/splash_page.dart
+++ b/lib/app/modules/splash/presentation/pages/splash_page.dart
@@ -1,5 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ziggle/app/modules/core/presentation/bloc/link_bloc.dart';
 import 'package:ziggle/app/router.gr.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
@@ -23,6 +25,14 @@ class _SplashPageState extends State<SplashPage> {
         widget.delay ? const Duration(seconds: 1) : Duration.zero,
         () {
           if (!mounted) return;
+          final linkData =
+              context.read<LinkBloc>().state.whenOrNull(loaded: (link) => link);
+          if (linkData != null) {
+            context.router
+              ..replaceAll([const FeedRoute()])
+              ..replaceNamed(linkData);
+            return;
+          }
           context.router.replaceAll([const FeedRoute()]);
         },
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ziggle
 description: ziggle
 publish_to: 'none'
-version: 4.1.8
+version: 4.2.0
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
앱이 terminated 상태일 때 링크를 누르는 경우에 공지가 안 보이는 문제가 있습니다
해당 문제를 해결하였습니다

같은 맥락으로 알림을 terminated 상태에서 눌렀을 때 공지 페이지가 안 보이는 문제도 수정 되었을 것으로 보입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 링크 처리 로직 개선
	- 스플래시 페이지에서 동적 라우팅 지원

- **버그 수정**
	- 링크 스트림 처리 메커니즘 최적화

- **버전 업데이트**
	- 애플리케이션 버전 4.1.8에서 4.2.0으로 업그레이드
<!-- end of auto-generated comment: release notes by coderabbit.ai -->