### PR TITLE
fix: wrong timezone in notice detail

### DIFF
--- a/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
@@ -172,7 +172,7 @@ class _NoticeRendererState extends State<NoticeRenderer> {
                       Text(
                         DateFormat.yMd()
                             .add_Hm()
-                            .format(widget.notice.createdAt),
+                            .format(widget.notice.createdAt.toLocal()),
                         style: const TextStyle(
                           fontSize: 14,
                           fontWeight: FontWeight.w500,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 공지 생성 날짜가 이제 사용자의 로컬 시간대로 정확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->