### PR TITLE
feat: add write notice in group

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -13,6 +13,7 @@ import 'package:ziggle/app/modules/user/presentation/bloc/auth_bloc.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/developer_option_bloc.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/group_auth_bloc.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
+import 'package:ziggle/app/modules/groups/presentation/blocs/group_bloc.dart';
 import 'package:ziggle/app/router.dart';
 import 'package:ziggle/app/router_observer.dart';
 import 'package:ziggle/app/values/palette.dart';
@@ -87,6 +88,10 @@ class _Providers extends StatelessWidget {
           create: (_) =>
               sl<DeveloperOptionBloc>()..add(const DeveloperOptionEvent.load()),
         ),
+        BlocProvider(
+          lazy: false,
+          create: (_) => sl<GroupBloc>()..add(GroupEvent.load()),
+        ),
       ],
       child: MultiBlocListener(
         listeners: [
@@ -112,6 +117,17 @@ class _Providers extends StatelessWidget {
                 _appRouter.pushNamed(s.link);
               }),
             ),
+          ),
+          BlocListener<GroupAuthBloc, GroupAuthState>(
+            listenWhen: (previous, current) =>
+                current.mapOrNull(
+                  unauthenticated: (_) => true,
+                  authenticated: (_) => true,
+                ) ??
+                false,
+            listener: (context, state) {
+              context.read<GroupBloc>().add(GroupEvent.load());
+            },
           ),
         ],
         child: child,

--- a/lib/app/modules/core/domain/enums/api_channel.dart
+++ b/lib/app/modules/core/domain/enums/api_channel.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart';
 enum ApiChannel {
   staging(
     'https://api.stg.ziggle.gistory.me/',
-    'https://api.stg.groups.gistory.me/',
+    'https://api.groups.gistory.me/',
   ),
   production(
     'https://api.ziggle.gistory.me/',

--- a/lib/app/modules/groups/presentation/blocs/group_bloc.dart
+++ b/lib/app/modules/groups/presentation/blocs/group_bloc.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:ziggle/app/modules/groups/domain/entities/group_list_entity.dart';
+import 'package:ziggle/app/modules/groups/domain/repository/group_repository.dart';
+
+part 'group_bloc.freezed.dart';
+
+@injectable
+class GroupBloc extends Bloc<GroupEvent, GroupState> {
+  final GroupRepository _repository;
+
+  GroupBloc(this._repository) : super(_Initial()) {
+    on<_Load>(_handleLoadOrRefresh);
+    on<_Refresh>(_handleLoadOrRefresh);
+  }
+
+  void _handleLoadOrRefresh(event, Emitter<GroupState> emit) async {
+    emit(_Loading());
+    try {
+      final groups = await _repository.getGroups();
+      emit(_Loaded(groups));
+    } on Exception catch (e) {
+      emit(_Error(e.toString()));
+    }
+  }
+
+  static Future<void> refresh(BuildContext context) async {
+    final bloc = context.read<GroupBloc>();
+    final blocker = bloc.stream.firstWhere((state) => !state.isLoading);
+    bloc.add(_Refresh());
+    await blocker;
+  }
+}
+
+@freezed
+class GroupEvent with _$GroupEvent {
+  const factory GroupEvent.load() = _Load;
+  const factory GroupEvent.refresh() = _Refresh;
+}
+
+@freezed
+class GroupState with _$GroupState {
+  const GroupState._();
+
+  const factory GroupState.initial() = _Initial;
+  const factory GroupState.loading() = _Loading;
+  const factory GroupState.loaded(GroupListEntity groups) = _Loaded;
+  const factory GroupState.error(String message) = _Error;
+
+  GroupListEntity? get groups => mapOrNull(loaded: (e) => e.groups);
+  bool get isLoading => this is _Loading;
+}

--- a/lib/app/modules/notices/data/data_sources/remote/notice_api.dart
+++ b/lib/app/modules/notices/data/data_sources/remote/notice_api.dart
@@ -26,12 +26,7 @@ abstract class NoticeApi {
   @POST('')
   Future<NoticeModel> createNotice(
     @Body() CreateNoticeModel model,
-  );
-
-  @POST('')
-  Future<NoticeModel> createGroupNotice(
-    @Body() CreateNoticeModel model,
-    @Header('Groups-Token') String groupsToken,
+    @Header('Groups-Token') String? groupsToken,
   );
 
   @GET('{id}')

--- a/lib/app/modules/notices/data/data_sources/remote/notice_api.dart
+++ b/lib/app/modules/notices/data/data_sources/remote/notice_api.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/retrofit.dart';
@@ -10,7 +12,6 @@ import 'package:ziggle/app/modules/notices/data/models/get_notices_query_model.d
 import 'package:ziggle/app/modules/notices/data/models/modify_notice_model.dart';
 import 'package:ziggle/app/modules/notices/data/models/notice_list_model.dart';
 import 'package:ziggle/app/modules/notices/data/models/notice_model.dart';
-
 part 'notice_api.g.dart';
 
 @injectable
@@ -23,7 +24,15 @@ abstract class NoticeApi {
   Future<NoticeListModel> getNotices(@Queries() GetNoticesQueryModel query);
 
   @POST('')
-  Future<NoticeModel> createNotice(@Body() CreateNoticeModel model);
+  Future<NoticeModel> createNotice(
+    @Body() CreateNoticeModel model,
+  );
+
+  @POST('')
+  Future<NoticeModel> createGroupNotice(
+    @Body() CreateNoticeModel model,
+    @Header('Groups-Token') String groupsToken,
+  );
 
   @GET('{id}')
   Future<NoticeModel> getNotice(

--- a/lib/app/modules/notices/data/data_sources/remote/ziggle_group_api.dart
+++ b/lib/app/modules/notices/data/data_sources/remote/ziggle_group_api.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:ziggle/app/modules/core/data/dio/ziggle_dio.dart';
+part 'ziggle_group_api.g.dart';
+
+@injectable
+@RestApi(baseUrl: 'group/')
+abstract class ZiggleGroupApi {
+  @factoryMethod
+  factory ZiggleGroupApi(ZiggleDio dio) = _ZiggleGroupApi;
+
+  @POST('token')
+  Future<String> getGroupToken();
+}

--- a/lib/app/modules/notices/data/data_sources/remote/ziggle_group_api.dart
+++ b/lib/app/modules/notices/data/data_sources/remote/ziggle_group_api.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:ziggle/app/modules/core/data/dio/ziggle_dio.dart';
+import 'package:ziggle/app/modules/notices/data/models/group_token_model.dart';
 part 'ziggle_group_api.g.dart';
 
 @injectable
@@ -11,5 +12,5 @@ abstract class ZiggleGroupApi {
   factory ZiggleGroupApi(ZiggleDio dio) = _ZiggleGroupApi;
 
   @POST('token')
-  Future<String> getGroupToken();
+  Future<GroupTokenModel> getGroupToken();
 }

--- a/lib/app/modules/notices/data/models/create_notice_model.dart
+++ b/lib/app/modules/notices/data/models/create_notice_model.dart
@@ -11,6 +11,7 @@ class CreateNoticeModel with _$CreateNoticeModel {
     required String body,
     DateTime? deadline,
     required NoticeCategory category,
+    String? groupId,
     @Default([]) List<int> tags,
     @Default([]) List<String> images,
     @Default([]) List<String> documents,

--- a/lib/app/modules/notices/data/models/group_token_model.dart
+++ b/lib/app/modules/notices/data/models/group_token_model.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'group_token_model.freezed.dart';
+part 'group_token_model.g.dart';
+
+@freezed
+class GroupTokenModel with _$GroupTokenModel {
+  const factory GroupTokenModel({
+    required String groupsToken,
+  }) = _GroupTokenModel;
+
+  factory GroupTokenModel.fromJson(Map<String, dynamic> json) =>
+      _$GroupTokenModelFromJson(json);
+}

--- a/lib/app/modules/notices/data/models/notice_model.dart
+++ b/lib/app/modules/notices/data/models/notice_model.dart
@@ -36,7 +36,7 @@ class NoticeModel with _$NoticeModel implements NoticeEntity {
     @Default([]) List<String> documentUrls,
     @Default(false) bool isReminded,
     required NoticeCategory category,
-    @Default(null) NoticeGroupEntity? group,
+    NoticeGroupEntity? group,
     required DateTime publishedAt,
   }) = _NoticeModel;
 

--- a/lib/app/modules/notices/data/models/notice_model.dart
+++ b/lib/app/modules/notices/data/models/notice_model.dart
@@ -35,7 +35,7 @@ class NoticeModel with _$NoticeModel implements NoticeEntity {
     @Default([]) List<String> documentUrls,
     @Default(false) bool isReminded,
     required NoticeCategory category,
-    String? groupName,
+    String? groupId,
     required DateTime publishedAt,
   }) = _NoticeModel;
 

--- a/lib/app/modules/notices/data/models/notice_model.dart
+++ b/lib/app/modules/notices/data/models/notice_model.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_entity.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_category.dart';
 
 import 'author_model.dart';
@@ -35,7 +36,7 @@ class NoticeModel with _$NoticeModel implements NoticeEntity {
     @Default([]) List<String> documentUrls,
     @Default(false) bool isReminded,
     required NoticeCategory category,
-    String? groupId,
+    @Default(null) NoticeGroupEntity? group,
     required DateTime publishedAt,
   }) = _NoticeModel;
 

--- a/lib/app/modules/notices/data/repositories/mock_notice_repository.dart
+++ b/lib/app/modules/notices/data/repositories/mock_notice_repository.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:injectable/injectable.dart';
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_entity.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_list_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_reaction_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_reaction.dart';
@@ -140,7 +141,7 @@ class MockNoticeRepository implements NoticeRepository {
     List<String> tags = const [],
     List<File> images = const [],
     List<File> documents = const [],
-    String? groupId,
+    NoticeGroupEntity? group,
   }) {
     throw UnimplementedError();
   }

--- a/lib/app/modules/notices/data/repositories/mock_notice_repository.dart
+++ b/lib/app/modules/notices/data/repositories/mock_notice_repository.dart
@@ -132,14 +132,16 @@ class MockNoticeRepository implements NoticeRepository {
   }
 
   @override
-  Future<NoticeEntity> write(
-      {required String title,
-      required String content,
-      DateTime? deadline,
-      required NoticeType type,
-      List<String> tags = const [],
-      List<File> images = const [],
-      List<File> documents = const []}) {
+  Future<NoticeEntity> write({
+    required String title,
+    required String content,
+    DateTime? deadline,
+    required NoticeType type,
+    List<String> tags = const [],
+    List<File> images = const [],
+    List<File> documents = const [],
+    String? groupId,
+  }) {
     throw UnimplementedError();
   }
 

--- a/lib/app/modules/notices/data/repositories/rest_notice_repository.dart
+++ b/lib/app/modules/notices/data/repositories/rest_notice_repository.dart
@@ -160,9 +160,8 @@ class RestNoticeRepository implements NoticeRepository {
     final uploadedDocuments = documents.isEmpty
         ? <String>[]
         : await _documentApi.uploadDocuments(documents);
-    final groupsTokenResponse = await _groupApi.getGroupToken();
-    String groupsToken = jsonDecode(groupsTokenResponse)['groupsToken'];
-    if (groupId == null) {
+    final groupsTokenResponce = await _groupApi.getGroupToken();
+    if (groupId != null) {
       return _api.createNotice(
         CreateNoticeModel(
           title: title,
@@ -174,21 +173,21 @@ class RestNoticeRepository implements NoticeRepository {
           documents: uploadedDocuments,
           groupId: groupId,
         ),
+        groupsTokenResponce.groupsToken,
       );
     }
-    return _api.createGroupNotice(
-      CreateNoticeModel(
-        title: title,
-        body: content,
-        deadline: deadline,
-        category: NoticeCategory.fromType(type)!,
-        tags: uploadedTags.map((tag) => tag.id).toList(),
-        images: uploadedImages,
-        documents: uploadedDocuments,
-        groupId: groupId,
-      ),
-      groupsToken,
-    );
+    return _api.createNotice(
+        CreateNoticeModel(
+          title: title,
+          body: content,
+          deadline: deadline,
+          category: NoticeCategory.fromType(type)!,
+          tags: uploadedTags.map((tag) => tag.id).toList(),
+          images: uploadedImages,
+          documents: uploadedDocuments,
+          groupId: groupId,
+        ),
+        null);
   }
 
   @override

--- a/lib/app/modules/notices/data/repositories/rest_notice_repository.dart
+++ b/lib/app/modules/notices/data/repositories/rest_notice_repository.dart
@@ -17,6 +17,7 @@ import 'package:ziggle/app/modules/notices/data/models/create_notice_model.dart'
 import 'package:ziggle/app/modules/notices/data/models/get_notices_query_model.dart';
 import 'package:ziggle/app/modules/notices/data/models/modify_notice_model.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_entity.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_list_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/tag_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_category.dart';
@@ -147,7 +148,7 @@ class RestNoticeRepository implements NoticeRepository {
     List<String> tags = const [],
     List<File> images = const [],
     List<File> documents = const [],
-    String? groupId,
+    NoticeGroupEntity? group,
   }) async {
     final uploadedTags = await Future.wait(
       tags.map((tag) async {
@@ -161,33 +162,20 @@ class RestNoticeRepository implements NoticeRepository {
         ? <String>[]
         : await _documentApi.uploadDocuments(documents);
     final groupsTokenResponce = await _groupApi.getGroupToken();
-    if (groupId != null) {
-      return _api.createNotice(
-        CreateNoticeModel(
-          title: title,
-          body: content,
-          deadline: deadline,
-          category: NoticeCategory.fromType(type)!,
-          tags: uploadedTags.map((tag) => tag.id).toList(),
-          images: uploadedImages,
-          documents: uploadedDocuments,
-          groupId: groupId,
-        ),
-        groupsTokenResponce.groupsToken,
-      );
-    }
+
     return _api.createNotice(
-        CreateNoticeModel(
-          title: title,
-          body: content,
-          deadline: deadline,
-          category: NoticeCategory.fromType(type)!,
-          tags: uploadedTags.map((tag) => tag.id).toList(),
-          images: uploadedImages,
-          documents: uploadedDocuments,
-          groupId: groupId,
-        ),
-        null);
+      CreateNoticeModel(
+        title: title,
+        body: content,
+        deadline: deadline,
+        category: NoticeCategory.fromType(type)!,
+        tags: uploadedTags.map((tag) => tag.id).toList(),
+        images: uploadedImages,
+        documents: uploadedDocuments,
+        groupId: group?.uuid,
+      ),
+      group?.uuid != null ? groupsTokenResponce.groupsToken : null,
+    );
   }
 
   @override

--- a/lib/app/modules/notices/data/repositories/rest_notice_repository.dart
+++ b/lib/app/modules/notices/data/repositories/rest_notice_repository.dart
@@ -1,8 +1,10 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
+import 'package:ziggle/app/modules/notices/data/data_sources/remote/ziggle_group_api.dart';
 import 'package:ziggle/app/modules/notices/data/data_sources/remote/document_api.dart';
 import 'package:ziggle/app/modules/notices/data/data_sources/remote/image_api.dart';
 import 'package:ziggle/app/modules/notices/data/data_sources/remote/notice_api.dart';
@@ -28,12 +30,14 @@ class RestNoticeRepository implements NoticeRepository {
   final TagApi _tagApi;
   final ImageApi _imageApi;
   final DocumentApi _documentApi;
+  final ZiggleGroupApi _groupApi;
 
   RestNoticeRepository(
     this._api,
     this._tagApi,
     this._imageApi,
     this._documentApi,
+    this._groupApi,
   );
 
   @override
@@ -135,14 +139,16 @@ class RestNoticeRepository implements NoticeRepository {
   }
 
   @override
-  Future<NoticeEntity> write(
-      {required String title,
-      required String content,
-      DateTime? deadline,
-      required NoticeType type,
-      List<String> tags = const [],
-      List<File> images = const [],
-      List<File> documents = const []}) async {
+  Future<NoticeEntity> write({
+    required String title,
+    required String content,
+    DateTime? deadline,
+    required NoticeType type,
+    List<String> tags = const [],
+    List<File> images = const [],
+    List<File> documents = const [],
+    String? groupId,
+  }) async {
     final uploadedTags = await Future.wait(
       tags.map((tag) async {
         final existingTag = await _getTag(tag);
@@ -154,15 +160,35 @@ class RestNoticeRepository implements NoticeRepository {
     final uploadedDocuments = documents.isEmpty
         ? <String>[]
         : await _documentApi.uploadDocuments(documents);
-    return _api.createNotice(CreateNoticeModel(
-      title: title,
-      body: content,
-      deadline: deadline,
-      category: NoticeCategory.fromType(type)!,
-      tags: uploadedTags.map((tag) => tag.id).toList(),
-      images: uploadedImages,
-      documents: uploadedDocuments,
-    ));
+    final groupsTokenResponse = await _groupApi.getGroupToken();
+    String groupsToken = jsonDecode(groupsTokenResponse)['groupsToken'];
+    if (groupId == null) {
+      return _api.createNotice(
+        CreateNoticeModel(
+          title: title,
+          body: content,
+          deadline: deadline,
+          category: NoticeCategory.fromType(type)!,
+          tags: uploadedTags.map((tag) => tag.id).toList(),
+          images: uploadedImages,
+          documents: uploadedDocuments,
+          groupId: groupId,
+        ),
+      );
+    }
+    return _api.createGroupNotice(
+      CreateNoticeModel(
+        title: title,
+        body: content,
+        deadline: deadline,
+        category: NoticeCategory.fromType(type)!,
+        tags: uploadedTags.map((tag) => tag.id).toList(),
+        images: uploadedImages,
+        documents: uploadedDocuments,
+        groupId: groupId,
+      ),
+      groupsToken,
+    );
   }
 
   @override

--- a/lib/app/modules/notices/domain/entities/notice_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_entity.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_write_draft_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_category.dart';
 import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
@@ -29,7 +30,7 @@ class NoticeEntity {
   final List<String> documentUrls;
   final bool isReminded;
   final DateTime publishedAt;
-  final String? groupId;
+  final NoticeGroupEntity? group;
   final NoticeCategory category;
 
   NoticeEntity({
@@ -50,7 +51,7 @@ class NoticeEntity {
     required this.documentUrls,
     required this.isReminded,
     required this.publishedAt,
-    required this.groupId,
+    required this.group,
     required this.category,
   });
 
@@ -72,7 +73,7 @@ class NoticeEntity {
         author: AuthorEntity(name: '', uuid: ''),
         isReminded: false,
         publishedAt: DateTime.now(),
-        groupId: null,
+        group: null,
         category: NoticeCategory.etc,
       );
   factory NoticeEntity.mock({
@@ -106,7 +107,7 @@ class NoticeEntity {
         documentUrls: [],
         isReminded: isReminded,
         publishedAt: DateTime.now(),
-        groupId: null,
+        group: null,
         category: category,
       );
   factory NoticeEntity.fromDraft({
@@ -131,7 +132,7 @@ class NoticeEntity {
         documentUrls: [],
         isReminded: false,
         publishedAt: DateTime.now(),
-        groupId: draft.groupId,
+        group: draft.group,
         category: NoticeCategory.fromType(draft.type!)!,
       );
 }
@@ -175,7 +176,7 @@ extension NoticeEntityExtension on NoticeEntity {
         documentUrls: documentUrls,
         isReminded: isReminded,
         publishedAt: publishedAt ?? this.publishedAt,
-        groupId: groupId,
+        group: group,
         category: category,
       );
 
@@ -235,7 +236,7 @@ extension NoticeEntityExtension on NoticeEntity {
         documentUrls: documentUrls,
         isReminded: isReminded,
         publishedAt: publishedAt,
-        groupId: groupId,
+        group: group,
         category: category,
       );
 }

--- a/lib/app/modules/notices/domain/entities/notice_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_entity.dart
@@ -29,7 +29,7 @@ class NoticeEntity {
   final List<String> documentUrls;
   final bool isReminded;
   final DateTime publishedAt;
-  final String? groupName;
+  final String? groupId;
   final NoticeCategory category;
 
   NoticeEntity({
@@ -50,7 +50,7 @@ class NoticeEntity {
     required this.documentUrls,
     required this.isReminded,
     required this.publishedAt,
-    required this.groupName,
+    required this.groupId,
     required this.category,
   });
 
@@ -72,7 +72,7 @@ class NoticeEntity {
         author: AuthorEntity(name: '', uuid: ''),
         isReminded: false,
         publishedAt: DateTime.now(),
-        groupName: null,
+        groupId: null,
         category: NoticeCategory.etc,
       );
   factory NoticeEntity.mock({
@@ -106,7 +106,7 @@ class NoticeEntity {
         documentUrls: [],
         isReminded: isReminded,
         publishedAt: DateTime.now(),
-        groupName: null,
+        groupId: null,
         category: category,
       );
   factory NoticeEntity.fromDraft({
@@ -131,7 +131,7 @@ class NoticeEntity {
         documentUrls: [],
         isReminded: false,
         publishedAt: DateTime.now(),
-        groupName: null,
+        groupId: draft.groupId,
         category: NoticeCategory.fromType(draft.type!)!,
       );
 }
@@ -175,7 +175,7 @@ extension NoticeEntityExtension on NoticeEntity {
         documentUrls: documentUrls,
         isReminded: isReminded,
         publishedAt: publishedAt ?? this.publishedAt,
-        groupName: groupName,
+        groupId: groupId,
         category: category,
       );
 
@@ -235,7 +235,7 @@ extension NoticeEntityExtension on NoticeEntity {
         documentUrls: documentUrls,
         isReminded: isReminded,
         publishedAt: publishedAt,
-        groupName: groupName,
+        groupId: groupId,
         category: category,
       );
 }

--- a/lib/app/modules/notices/domain/entities/notice_group_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_group_entity.dart
@@ -1,31 +1,29 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ziggle/app/modules/groups/domain/entities/group_entity.dart';
 
-class NoticeGroupEntity {
-  final String? uuid;
-  final String? name;
-  final String? description;
-  final DateTime? createdAt;
-  final String? presidentUuid;
-  final int? memberCount;
-  final DateTime? verifiedAt;
-  final bool? verified;
-  final DateTime? deletedAt;
-  final String? notionPageId;
-  final String? profileImageKey;
+part 'notice_group_entity.freezed.dart';
+part 'notice_group_entity.g.dart';
 
-  NoticeGroupEntity({
-    this.uuid,
-    this.name,
-    this.description,
-    this.createdAt,
-    this.presidentUuid,
-    this.memberCount,
-    this.verifiedAt,
-    this.verified,
-    this.deletedAt,
-    this.notionPageId,
-    this.profileImageKey,
-  });
+@freezed
+class NoticeGroupEntity with _$NoticeGroupEntity {
+  const NoticeGroupEntity._();
+
+  const factory NoticeGroupEntity({
+    required String uuid,
+    required String name,
+    required String description,
+    required DateTime createdAt,
+    required String presidentUuid,
+    required int? memberCount,
+    required DateTime? verifiedAt,
+    required bool? verified,
+    required DateTime? deletedAt,
+    required String? notionPageId,
+    required String? profileImageKey,
+  }) = _NoticeGroupEntity;
+
+  factory NoticeGroupEntity.fromJson(Map<String, dynamic> json) =>
+      _$NoticeGroupEntityFromJson(json);
 
   factory NoticeGroupEntity.fromGroupModel(GroupEntity model) {
     return NoticeGroupEntity(
@@ -34,9 +32,9 @@ class NoticeGroupEntity {
       description: model.description,
       createdAt: model.createdAt,
       presidentUuid: model.presidentUuid,
-      memberCount: model.memberCount,
+      memberCount: model.memberCount ?? 0,
       verifiedAt: model.verifiedAt,
-      verified: model.verified,
+      verified: model.verified ?? false,
       deletedAt: model.deletedAt,
       notionPageId: model.notionPageId,
       profileImageKey: model.profileImageKey,

--- a/lib/app/modules/notices/domain/entities/notice_group_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_group_entity.dart
@@ -1,0 +1,45 @@
+import 'package:ziggle/app/modules/groups/domain/entities/group_entity.dart';
+
+class NoticeGroupEntity {
+  final String? uuid;
+  final String? name;
+  final String? description;
+  final DateTime? createdAt;
+  final String? presidentUuid;
+  final int? memberCount;
+  final DateTime? verifiedAt;
+  final bool? verified;
+  final DateTime? deletedAt;
+  final String? notionPageId;
+  final String? profileImageKey;
+
+  NoticeGroupEntity({
+    this.uuid,
+    this.name,
+    this.description,
+    this.createdAt,
+    this.presidentUuid,
+    this.memberCount,
+    this.verifiedAt,
+    this.verified,
+    this.deletedAt,
+    this.notionPageId,
+    this.profileImageKey,
+  });
+
+  factory NoticeGroupEntity.fromGroupModel(GroupEntity model) {
+    return NoticeGroupEntity(
+      uuid: model.uuid,
+      name: model.name,
+      description: model.description,
+      createdAt: model.createdAt,
+      presidentUuid: model.presidentUuid,
+      memberCount: model.memberCount,
+      verifiedAt: model.verifiedAt,
+      verified: model.verified,
+      deletedAt: model.deletedAt,
+      notionPageId: model.notionPageId,
+      profileImageKey: model.profileImageKey,
+    );
+  }
+}

--- a/lib/app/modules/notices/domain/entities/notice_group_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_group_entity.dart
@@ -9,11 +9,11 @@ class NoticeGroupEntity with _$NoticeGroupEntity {
   const NoticeGroupEntity._();
 
   const factory NoticeGroupEntity({
-    required String uuid,
-    required String name,
-    required String description,
-    required DateTime createdAt,
-    required String presidentUuid,
+    required String? uuid,
+    required String? name,
+    required String? description,
+    required DateTime? createdAt,
+    required String? presidentUuid,
     required int? memberCount,
     required DateTime? verifiedAt,
     required bool? verified,

--- a/lib/app/modules/notices/domain/entities/notice_write_draft_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_write_draft_entity.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 
 part 'notice_write_draft_entity.freezed.dart';
@@ -17,7 +18,7 @@ class NoticeWriteDraftEntity with _$NoticeWriteDraftEntity {
     NoticeType? type,
     @Default([]) List<String> tags,
     DateTime? deadline,
-    String? groupId,
+    NoticeGroupEntity? group,
     @Default({}) Map<Language, String> additionalContent,
   }) = _NoticeWriteDraftEntity;
 

--- a/lib/app/modules/notices/domain/entities/notice_write_draft_entity.dart
+++ b/lib/app/modules/notices/domain/entities/notice_write_draft_entity.dart
@@ -17,6 +17,7 @@ class NoticeWriteDraftEntity with _$NoticeWriteDraftEntity {
     NoticeType? type,
     @Default([]) List<String> tags,
     DateTime? deadline,
+    String? groupId,
     @Default({}) Map<Language, String> additionalContent,
   }) = _NoticeWriteDraftEntity;
 

--- a/lib/app/modules/notices/domain/repositories/notice_repository.dart
+++ b/lib/app/modules/notices/domain/repositories/notice_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 
 import '../entities/notice_entity.dart';
 import '../entities/notice_list_entity.dart';
@@ -28,7 +29,7 @@ abstract class NoticeRepository {
     List<String> tags = const [],
     List<File> images = const [],
     List<File> documents = const [],
-    String? groupId,
+    NoticeGroupEntity? group,
   });
   Future<NoticeEntity> modify({
     required int id,

--- a/lib/app/modules/notices/domain/repositories/notice_repository.dart
+++ b/lib/app/modules/notices/domain/repositories/notice_repository.dart
@@ -28,6 +28,7 @@ abstract class NoticeRepository {
     List<String> tags = const [],
     List<File> images = const [],
     List<File> documents = const [],
+    String? groupId,
   });
   Future<NoticeEntity> modify({
     required int id,

--- a/lib/app/modules/notices/presentation/bloc/notice_write_bloc.dart
+++ b/lib/app/modules/notices/presentation/bloc/notice_write_bloc.dart
@@ -5,6 +5,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:ziggle/app/modules/core/domain/enums/language.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_entity.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/entities/notice_write_draft_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 import 'package:ziggle/app/modules/notices/domain/repositories/draft_save_repository.dart';
@@ -45,7 +46,7 @@ class NoticeWriteBloc extends Bloc<NoticeWriteEvent, NoticeWriteState> {
           type: event.type,
           tags: event.tags,
           deadline: event.deadline,
-          groupId: event.groupId,
+          group: event.group,
         ))));
     on<_AddAdditional>((event, emit) => emit(_Draft(state.draft.copyWith(
           deadline: event.deadline,
@@ -54,6 +55,7 @@ class NoticeWriteBloc extends Bloc<NoticeWriteEvent, NoticeWriteState> {
     on<_Publish>((event, emit) async {
       try {
         emit(_Loading(state.draft));
+
         if (event.prevNotice != null) {
           final notice = event.prevNotice!;
           if (!notice.isPublished &&
@@ -99,7 +101,7 @@ class NoticeWriteBloc extends Bloc<NoticeWriteEvent, NoticeWriteState> {
             tags: state.draft.tags,
             images: state.draft.images,
             deadline: state.draft.deadline,
-            groupId: state.draft.groupId,
+            group: state.draft.group,
           );
           if (state.draft.bodies.containsKey(Language.en)) {
             await _repository.writeForeign(
@@ -138,7 +140,7 @@ class NoticeWriteEvent {
     required NoticeType type,
     required List<String> tags,
     DateTime? deadline,
-    String? groupId,
+    NoticeGroupEntity? group,
   }) = _SetConfig;
   const factory NoticeWriteEvent.addAdditional({
     DateTime? deadline,

--- a/lib/app/modules/notices/presentation/bloc/notice_write_bloc.dart
+++ b/lib/app/modules/notices/presentation/bloc/notice_write_bloc.dart
@@ -45,6 +45,7 @@ class NoticeWriteBloc extends Bloc<NoticeWriteEvent, NoticeWriteState> {
           type: event.type,
           tags: event.tags,
           deadline: event.deadline,
+          groupId: event.groupId,
         ))));
     on<_AddAdditional>((event, emit) => emit(_Draft(state.draft.copyWith(
           deadline: event.deadline,
@@ -98,6 +99,7 @@ class NoticeWriteBloc extends Bloc<NoticeWriteEvent, NoticeWriteState> {
             tags: state.draft.tags,
             images: state.draft.images,
             deadline: state.draft.deadline,
+            groupId: state.draft.groupId,
           );
           if (state.draft.bodies.containsKey(Language.en)) {
             await _repository.writeForeign(
@@ -136,6 +138,7 @@ class NoticeWriteEvent {
     required NoticeType type,
     required List<String> tags,
     DateTime? deadline,
+    String? groupId,
   }) = _SetConfig;
   const factory NoticeWriteEvent.addAdditional({
     DateTime? deadline,

--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
-import 'package:ziggle/app/di/locator.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_bottom_sheet.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
@@ -11,17 +10,18 @@ import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_toggle_but
 import 'package:ziggle/app/modules/core/data/models/analytics_event.dart';
 import 'package:ziggle/app/modules/core/domain/enums/page_source.dart';
 import 'package:ziggle/app/modules/core/domain/repositories/analytics_repository.dart';
+import 'package:ziggle/app/modules/groups/presentation/blocs/group_bloc.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 import 'package:ziggle/app/modules/notices/presentation/bloc/notice_write_bloc.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/account_selector.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/deadline_selector.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/tag.dart';
+import 'package:ziggle/app/modules/user/presentation/bloc/group_auth_bloc.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
 import 'package:ziggle/app/router.gr.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
 import 'package:ziggle/gen/strings.g.dart';
-import 'package:ziggle/app/modules/groups/presentation/blocs/group_management_main_bloc.dart';
 
 @RoutePage()
 class NoticeWriteConfigPage extends StatefulWidget {
@@ -44,6 +44,8 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
   late DateTime? _deadline = _draft.deadline;
   late NoticeType? _type = _draft.type;
   late final List<String> _tags = _draft.tags.toList();
+  late String? _groupId = _draft.groupId;
+  String? _groupName;
 
   void _save() {
     // TODO: is there any way to save when type is not set?
@@ -52,6 +54,7 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
           deadline: _deadline,
           type: _type!,
           tags: _tags,
+          groupId: _groupId,
         ));
   }
 
@@ -142,28 +145,46 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
               const SizedBox(width: 5),
               Assets.images.defaultProfile.image(width: 40),
               const SizedBox(width: 10),
-              BlocBuilder<UserBloc, UserState>(
-                builder: (context, userState) {
-                  return Row(children: [
-                    Text(
-                      userState.user!.name,
-                      style: TextStyle(
-                        fontSize: 18,
-                        color: Palette.black,
-                        fontWeight: FontWeight.w600,
+              BlocBuilder<GroupBloc, GroupState>(
+                  builder: (context, groupState) {
+                return BlocBuilder<UserBloc, UserState>(
+                  builder: (context, userState) {
+                    if (groupState.groups != null) {
+                      for (int i = 0; i < groupState.groups!.list.length; i++) {
+                        if (groupState.groups!.list[i].uuid == _groupId) {
+                          _groupName = groupState.groups!.list[i].name;
+                          break;
+                        }
+                        _groupName = null;
+                      }
+                    }
+                    return Row(children: [
+                      Text(
+                        _groupId != null
+                            ? (_groupName ?? "Unknown Group")
+                            : userState.user!.name,
+                        style: TextStyle(
+                          fontSize: 18,
+                          color: Palette.black,
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
-                    ),
-                  ]);
-                },
-              ),
+                    ]);
+                  },
+                );
+              }),
               const Spacer(),
               ZigglePressable(
                 onPressed: () async {
-                  final userAccount = await ZiggleBottomSheet.show<DateTime>(
+                  context.read<GroupAuthBloc>().add(GroupAuthEvent.login());
+                  final userAccount = await ZiggleBottomSheet.show<String>(
                     context: context,
                     title: context.t.notice.write.changeAccount,
-                    builder: (context) => AccountSelector(),
+                    builder: (context) => AccountSelector(
+                      onChanged: (v) => Navigator.pop(context, v),
+                    ),
                   );
+                  setState(() => _groupId = userAccount);
                 },
                 child: Row(
                   children: [

--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
+import 'package:ziggle/app/di/locator.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_app_bar.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_bottom_sheet.dart';
 import 'package:ziggle/app/modules/common/presentation/widgets/ziggle_button.dart';
@@ -12,12 +13,15 @@ import 'package:ziggle/app/modules/core/domain/enums/page_source.dart';
 import 'package:ziggle/app/modules/core/domain/repositories/analytics_repository.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 import 'package:ziggle/app/modules/notices/presentation/bloc/notice_write_bloc.dart';
+import 'package:ziggle/app/modules/notices/presentation/widgets/account_selector.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/deadline_selector.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/tag.dart';
+import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
 import 'package:ziggle/app/router.gr.dart';
 import 'package:ziggle/app/values/palette.dart';
 import 'package:ziggle/gen/assets.gen.dart';
 import 'package:ziggle/gen/strings.g.dart';
+import 'package:ziggle/app/modules/groups/presentation/blocs/group_management_main_bloc.dart';
 
 @RoutePage()
 class NoticeWriteConfigPage extends StatefulWidget {
@@ -95,6 +99,8 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
             padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
             child: Column(
               children: [
+                _buildChangeAccount(),
+                const SizedBox(height: 25),
                 _buildDeadline(),
                 const SizedBox(height: 25),
                 _buildCategory(),
@@ -117,6 +123,69 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildChangeAccount() {
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: const BoxDecoration(
+        color: Palette.grayLight,
+        borderRadius: BorderRadius.all(Radius.circular(10)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const SizedBox(width: 5),
+              Assets.images.defaultProfile.image(width: 40),
+              const SizedBox(width: 10),
+              BlocBuilder<UserBloc, UserState>(
+                builder: (context, userState) {
+                  return Row(children: [
+                    Text(
+                      userState.user!.name,
+                      style: TextStyle(
+                        fontSize: 18,
+                        color: Palette.black,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ]);
+                },
+              ),
+              const Spacer(),
+              ZigglePressable(
+                onPressed: () async {
+                  final userAccount = await ZiggleBottomSheet.show<DateTime>(
+                    context: context,
+                    title: context.t.notice.write.changeAccount,
+                    builder: (context) => AccountSelector(),
+                  );
+                },
+                child: Row(
+                  children: [
+                    Text(
+                      context.t.notice.write.changeAccount,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Palette.grayText,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(width: 5),
+                    Assets.icons.arrowRight.svg(
+                      width: 20,
+                      height: 20,
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -45,7 +45,7 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
   late DateTime? _deadline = _draft.deadline;
   late NoticeType? _type = _draft.type;
   late final List<String> _tags = _draft.tags.toList();
-  late NoticeGroupEntity _groupEntity = NoticeGroupEntity();
+  NoticeGroupEntity? _groupEntity;
 
   void _save() {
     // TODO: is there any way to save when type is not set?
@@ -54,7 +54,7 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
           deadline: _deadline,
           type: _type!,
           tags: _tags,
-          groupId: _groupEntity.uuid,
+          group: _groupEntity,
         ));
   }
 
@@ -151,8 +151,8 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
                   builder: (context, userState) {
                     return Row(children: [
                       Text(
-                        _groupEntity.uuid != null
-                            ? (_groupEntity.name ?? "Unknown Group")
+                        _groupEntity?.uuid != null
+                            ? (_groupEntity?.name ?? "Unknown Group")
                             : userState.user!.name,
                         style: TextStyle(
                           fontSize: 18,
@@ -177,7 +177,8 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
                       onChanged: (v) => Navigator.pop(context, v),
                     ),
                   );
-                  setState(() => _groupEntity = groupEntity!);
+
+                  setState(() => _groupEntity = groupEntity);
                 },
                 child: Row(
                   children: [

--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -177,14 +177,14 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
               ZigglePressable(
                 onPressed: () async {
                   context.read<GroupAuthBloc>().add(GroupAuthEvent.login());
-                  final userAccount = await ZiggleBottomSheet.show<String>(
+                  final groupId = await ZiggleBottomSheet.show<String>(
                     context: context,
                     title: context.t.notice.write.changeAccount,
                     builder: (context) => AccountSelector(
                       onChanged: (v) => Navigator.pop(context, v),
                     ),
                   );
-                  setState(() => _groupId = userAccount);
+                  setState(() => _groupId = groupId);
                 },
                 child: Row(
                   children: [

--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -176,6 +176,7 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
               const Spacer(),
               ZigglePressable(
                 onPressed: () async {
+                  // TODO: Remove after implementing the GroupAuth
                   context.read<GroupAuthBloc>().add(GroupAuthEvent.login());
                   final groupId = await ZiggleBottomSheet.show<String>(
                     context: context,

--- a/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
+++ b/lib/app/modules/notices/presentation/pages/notice_write_config_page.dart
@@ -11,6 +11,7 @@ import 'package:ziggle/app/modules/core/data/models/analytics_event.dart';
 import 'package:ziggle/app/modules/core/domain/enums/page_source.dart';
 import 'package:ziggle/app/modules/core/domain/repositories/analytics_repository.dart';
 import 'package:ziggle/app/modules/groups/presentation/blocs/group_bloc.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart';
 import 'package:ziggle/app/modules/notices/presentation/bloc/notice_write_bloc.dart';
 import 'package:ziggle/app/modules/notices/presentation/widgets/account_selector.dart';
@@ -44,8 +45,7 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
   late DateTime? _deadline = _draft.deadline;
   late NoticeType? _type = _draft.type;
   late final List<String> _tags = _draft.tags.toList();
-  late String? _groupId = _draft.groupId;
-  String? _groupName;
+  late NoticeGroupEntity _groupEntity = NoticeGroupEntity();
 
   void _save() {
     // TODO: is there any way to save when type is not set?
@@ -54,7 +54,7 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
           deadline: _deadline,
           type: _type!,
           tags: _tags,
-          groupId: _groupId,
+          groupId: _groupEntity.uuid,
         ));
   }
 
@@ -149,19 +149,10 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
                   builder: (context, groupState) {
                 return BlocBuilder<UserBloc, UserState>(
                   builder: (context, userState) {
-                    if (groupState.groups != null) {
-                      for (int i = 0; i < groupState.groups!.list.length; i++) {
-                        if (groupState.groups!.list[i].uuid == _groupId) {
-                          _groupName = groupState.groups!.list[i].name;
-                          break;
-                        }
-                        _groupName = null;
-                      }
-                    }
                     return Row(children: [
                       Text(
-                        _groupId != null
-                            ? (_groupName ?? "Unknown Group")
+                        _groupEntity.uuid != null
+                            ? (_groupEntity.name ?? "Unknown Group")
                             : userState.user!.name,
                         style: TextStyle(
                           fontSize: 18,
@@ -178,14 +169,15 @@ class _NoticeWriteConfigPageState extends State<NoticeWriteConfigPage>
                 onPressed: () async {
                   // TODO: Remove after implementing the GroupAuth
                   context.read<GroupAuthBloc>().add(GroupAuthEvent.login());
-                  final groupId = await ZiggleBottomSheet.show<String>(
+                  final groupEntity =
+                      await ZiggleBottomSheet.show<NoticeGroupEntity>(
                     context: context,
                     title: context.t.notice.write.changeAccount,
                     builder: (context) => AccountSelector(
                       onChanged: (v) => Navigator.pop(context, v),
                     ),
                   );
-                  setState(() => _groupId = groupId);
+                  setState(() => _groupEntity = groupEntity!);
                 },
                 child: Row(
                   children: [

--- a/lib/app/modules/notices/presentation/widgets/account_selector.dart
+++ b/lib/app/modules/notices/presentation/widgets/account_selector.dart
@@ -46,7 +46,7 @@ class _AccountSelectorState extends State<AccountSelector> {
                             profileImage:
                                 Assets.images.defaultProfile.image(width: 36),
                             onPressed: () {
-                              widget.onChanged(NoticeGroupEntity());
+                              widget.onChanged(null);
                             },
                           );
                         } else {

--- a/lib/app/modules/notices/presentation/widgets/account_selector.dart
+++ b/lib/app/modules/notices/presentation/widgets/account_selector.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ziggle/app/di/locator.dart';
-import 'package:ziggle/app/modules/groups/presentation/blocs/group_management_main_bloc.dart';
+import 'package:lottie/lottie.dart';
+import 'package:ziggle/app/modules/groups/presentation/blocs/group_bloc.dart';
 import 'package:ziggle/app/modules/groups/presentation/widgets/group_list_item.dart';
+import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
+import 'package:ziggle/gen/assets.gen.dart';
 
 class AccountSelector extends StatefulWidget {
   const AccountSelector({
     super.key,
+    required this.onChanged,
   });
+
+  final ValueChanged<String?> onChanged;
 
   @override
   State<AccountSelector> createState() => _AccountSelectorState();
@@ -16,26 +21,53 @@ class AccountSelector extends StatefulWidget {
 class _AccountSelectorState extends State<AccountSelector> {
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) =>
-          sl<GroupManagementMainBloc>()..add(GroupManagementMainEvent.load()),
-      child: BlocBuilder<GroupManagementMainBloc, GroupManagementMainState>(
-        builder: (context, state) => Padding(
-          padding: EdgeInsets.symmetric(horizontal: 15),
-          child: ListView.separated(
-            shrinkWrap: true,
-            physics: NeverScrollableScrollPhysics(),
-            itemCount: 3,
-            itemBuilder: (context, index) {
-              return GroupListItem(
-                name: "Test",
-                onPressed: () {},
-              );
-            },
-            separatorBuilder: (context, index) => SizedBox(height: 12),
-          ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        BlocBuilder<UserBloc, UserState>(
+          builder: (context, userState) {
+            return BlocBuilder<GroupBloc, GroupState>(
+              builder: (context, groupState) {
+                if (groupState.isLoading || userState.isLoading) {
+                  return Lottie.asset(Assets.lotties.loading,
+                      width: 30, height: 30);
+                }
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 15),
+                  child: groupState.groups == null
+                      ? null
+                      : ListView.separated(
+                          shrinkWrap: true,
+                          itemCount: groupState.groups!.list.length + 1,
+                          itemBuilder: (context, index) {
+                            if (index == 0) {
+                              return GroupListItem(
+                                name: userState.user!.name,
+                                profileImage: Assets.images.defaultProfile
+                                    .image(width: 36),
+                                onPressed: () {
+                                  widget.onChanged(null);
+                                },
+                              );
+                            } else {
+                              return GroupListItem(
+                                name: groupState.groups!.list[index - 1].name,
+                                onPressed: () {
+                                  widget.onChanged(
+                                      groupState.groups!.list[index - 1].uuid);
+                                },
+                              );
+                            }
+                          },
+                          separatorBuilder: (context, index) =>
+                              const SizedBox(height: 12),
+                        ),
+                );
+              },
+            );
+          },
         ),
-      ),
+      ],
     );
   }
 }

--- a/lib/app/modules/notices/presentation/widgets/account_selector.dart
+++ b/lib/app/modules/notices/presentation/widgets/account_selector.dart
@@ -25,48 +25,43 @@ class _AccountSelectorState extends State<AccountSelector> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        BlocBuilder<UserBloc, UserState>(
-          builder: (context, userState) {
-            return BlocBuilder<GroupBloc, GroupState>(
-              builder: (context, groupState) {
-                if (groupState.isLoading || userState.isLoading) {
-                  return Lottie.asset(Assets.lotties.loading,
-                      width: 30, height: 30);
-                }
-                final groupList = groupState.groups;
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 15),
-                  child: groupList == null
-                      ? null
-                      : ListView.separated(
-                          shrinkWrap: true,
-                          itemCount: groupList.list.length + 1,
-                          itemBuilder: (context, index) {
-                            if (index == 0) {
-                              return GroupListItem(
-                                name: userState.user!.name,
-                                profileImage: Assets.images.defaultProfile
-                                    .image(width: 36),
-                                onPressed: () {
-                                  widget.onChanged(NoticeGroupEntity());
-                                },
-                              );
-                            } else {
-                              return GroupListItem(
-                                name: groupList.list[index - 1].name,
-                                onPressed: () {
-                                  widget.onChanged(
-                                      NoticeGroupEntity.fromGroupModel(
-                                          groupList.list[index - 1]));
-                                },
-                              );
-                            }
-                          },
-                          separatorBuilder: (context, index) =>
-                              const SizedBox(height: 12),
-                        ),
-                );
-              },
+        BlocBuilder<GroupBloc, GroupState>(
+          builder: (context, groupState) {
+            if (groupState.isLoading) {
+              return Lottie.asset(Assets.lotties.loading,
+                  width: 30, height: 30);
+            }
+            final groupList = groupState.groups;
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 15),
+              child: groupList == null
+                  ? null
+                  : ListView.separated(
+                      shrinkWrap: true,
+                      itemCount: groupList.list.length + 1,
+                      itemBuilder: (context, index) {
+                        if (index == 0) {
+                          return GroupListItem(
+                            name: UserBloc.userOrNull(context)!.name,
+                            profileImage:
+                                Assets.images.defaultProfile.image(width: 36),
+                            onPressed: () {
+                              widget.onChanged(NoticeGroupEntity());
+                            },
+                          );
+                        } else {
+                          return GroupListItem(
+                            name: groupList.list[index - 1].name,
+                            onPressed: () {
+                              widget.onChanged(NoticeGroupEntity.fromGroupModel(
+                                  groupList.list[index - 1]));
+                            },
+                          );
+                        }
+                      },
+                      separatorBuilder: (context, index) =>
+                          const SizedBox(height: 12),
+                    ),
             );
           },
         ),

--- a/lib/app/modules/notices/presentation/widgets/account_selector.dart
+++ b/lib/app/modules/notices/presentation/widgets/account_selector.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ziggle/app/di/locator.dart';
+import 'package:ziggle/app/modules/groups/presentation/blocs/group_management_main_bloc.dart';
+import 'package:ziggle/app/modules/groups/presentation/widgets/group_list_item.dart';
+
+class AccountSelector extends StatefulWidget {
+  const AccountSelector({
+    super.key,
+  });
+
+  @override
+  State<AccountSelector> createState() => _AccountSelectorState();
+}
+
+class _AccountSelectorState extends State<AccountSelector> {
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) =>
+          sl<GroupManagementMainBloc>()..add(GroupManagementMainEvent.load()),
+      child: BlocBuilder<GroupManagementMainBloc, GroupManagementMainState>(
+        builder: (context, state) => Padding(
+          padding: EdgeInsets.symmetric(horizontal: 15),
+          child: ListView.separated(
+            shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
+            itemCount: 3,
+            itemBuilder: (context, index) {
+              return GroupListItem(
+                name: "Test",
+                onPressed: () {},
+              );
+            },
+            separatorBuilder: (context, index) => SizedBox(height: 12),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/modules/notices/presentation/widgets/account_selector.dart
+++ b/lib/app/modules/notices/presentation/widgets/account_selector.dart
@@ -35,7 +35,14 @@ class _AccountSelectorState extends State<AccountSelector> {
             return Padding(
               padding: const EdgeInsets.symmetric(horizontal: 15),
               child: groupList == null
-                  ? null
+                  ? GroupListItem(
+                      name: UserBloc.userOrNull(context)!.name,
+                      profileImage:
+                          Assets.images.defaultProfile.image(width: 36),
+                      onPressed: () {
+                        widget.onChanged(null);
+                      },
+                    )
                   : ListView.separated(
                       shrinkWrap: true,
                       itemCount: groupList.list.length + 1,

--- a/lib/app/modules/notices/presentation/widgets/account_selector.dart
+++ b/lib/app/modules/notices/presentation/widgets/account_selector.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lottie/lottie.dart';
 import 'package:ziggle/app/modules/groups/presentation/blocs/group_bloc.dart';
 import 'package:ziggle/app/modules/groups/presentation/widgets/group_list_item.dart';
+import 'package:ziggle/app/modules/notices/domain/entities/notice_group_entity.dart';
 import 'package:ziggle/app/modules/user/presentation/bloc/user_bloc.dart';
 import 'package:ziggle/gen/assets.gen.dart';
 
@@ -12,7 +13,7 @@ class AccountSelector extends StatefulWidget {
     required this.onChanged,
   });
 
-  final ValueChanged<String?> onChanged;
+  final ValueChanged<NoticeGroupEntity?> onChanged;
 
   @override
   State<AccountSelector> createState() => _AccountSelectorState();
@@ -32,13 +33,14 @@ class _AccountSelectorState extends State<AccountSelector> {
                   return Lottie.asset(Assets.lotties.loading,
                       width: 30, height: 30);
                 }
+                final groupList = groupState.groups;
                 return Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 15),
-                  child: groupState.groups == null
+                  child: groupList == null
                       ? null
                       : ListView.separated(
                           shrinkWrap: true,
-                          itemCount: groupState.groups!.list.length + 1,
+                          itemCount: groupList.list.length + 1,
                           itemBuilder: (context, index) {
                             if (index == 0) {
                               return GroupListItem(
@@ -46,15 +48,16 @@ class _AccountSelectorState extends State<AccountSelector> {
                                 profileImage: Assets.images.defaultProfile
                                     .image(width: 36),
                                 onPressed: () {
-                                  widget.onChanged(null);
+                                  widget.onChanged(NoticeGroupEntity());
                                 },
                               );
                             } else {
                               return GroupListItem(
-                                name: groupState.groups!.list[index - 1].name,
+                                name: groupList.list[index - 1].name,
                                 onPressed: () {
                                   widget.onChanged(
-                                      groupState.groups!.list[index - 1].uuid);
+                                      NoticeGroupEntity.fromGroupModel(
+                                          groupList.list[index - 1]));
                                 },
                               );
                             }

--- a/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
+++ b/lib/app/modules/notices/presentation/widgets/notice_renderer.dart
@@ -172,7 +172,7 @@ class _NoticeRendererState extends State<NoticeRenderer> {
                       Text(
                         DateFormat.yMd()
                             .add_Hm()
-                            .format(widget.notice.createdAt),
+                            .format(widget.notice.createdAt.toLocal()),
                         style: const TextStyle(
                           fontSize: 14,
                           fontWeight: FontWeight.w500,


### PR DESCRIPTION


https://github.com/user-attachments/assets/7c9470c6-3ae2-4d63-b2d8-fee7c87394b1

아직 로직은 구현 중 (백엔드에서 그룹 생성 어떻게 합니까아악)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 공지 작성 페이지에 그룹 선택 기능 추가
	- 공지 작성 시 그룹 ID를 포함할 수 있는 기능 추가
	- 계정 선택을 위한 새로운 위젯 추가
	- 그룹 관련 기능을 통합한 상태 관리 개선
	- 그룹 토큰을 위한 새로운 데이터 모델 추가
	- 공지 그룹을 표현하는 새로운 엔티티 추가

- **버그 수정**
	- 공지 생성 날짜의 시간대 표시 문제 수정 (로컬 시간으로 변환)

- **기타 개선 사항**
	- 사용자 경험 개선을 위한 UI 업데이트
	- 공지 API에 그룹 공지 생성 기능 추가
	- 공지 모델에 그룹 ID 필드 추가
	- 공지 작성 블록에서 그룹 ID 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->