### PR TITLE
fix(deliver): skip upload screenshots

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -74,6 +74,7 @@ platform :ios do
       automatic_release: true,
       force: true,
       skip_binary_upload: true,
+      skip_screenshots: true,
       precheck_include_in_app_purchases: ENV['CI'] ? false : true,
       submission_information: {
         add_id_info_uses_idfa: false,


### PR DESCRIPTION
[애플이 API 안 고쳐줘서](https://forums.developer.apple.com/forums/thread/751867) 일단 CI/CD 돌게 하려고 스크린샷 업로드를 비활성화 하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 앱 제출 시 스크린샷 업로드 단계가 생략되어 배포 프로세스가 간소화되었습니다.
  - 이번 업데이트는 내부 제출 작업 과정을 효율적으로 개선하여, 배포 속도와 안정성 향상에 기여합니다. 다만, 최종 사용자 경험에는 직접적인 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->