### PR TITLE
fix: issue where '일' is appended after the date in korean

### DIFF
--- a/lib/app/modules/common/presentation/widgets/ziggle_date_time_picker.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_date_time_picker.dart
@@ -173,7 +173,7 @@ class _ZiggleDateTimePickerState extends State<ZiggleDateTimePicker> {
                           child: Padding(
                             padding: const EdgeInsets.symmetric(vertical: 8),
                             child: Text(
-                              DateFormat.d().format(day),
+                              DateFormat.d('en_US').format(day),
                               textAlign: TextAlign.center,
                               style: TextStyle(
                                 color: widget.dateTime?.isSameDate(day) ?? false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- 캘린더에 표시되는 날짜 형식을 미국 표준에 맞게 업데이트하여, 사용자에게 보다 일관된 날짜 표현을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->