### PR TITLE
chore(ci/cd): change deprecated option, wrong setting (cache)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         if: env.run == 'true' && matrix.os == 'Android'
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - uses: ruby/setup-ruby@v1
         if: env.run == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
+          cache: "gradle"
 
       - uses: ruby/setup-ruby@v1
         if: env.run == 'true'

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
+          cache: "gradle"
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.os == 'Android'
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -74,7 +74,7 @@ jobs:
       - name: install flutterfire
         run: flutter pub global activate flutterfire_cli
       - uses: actions/cache@v4
-        if: matrix.os == 'macos-15'
+        if: matrix.os == 'iOS'
         with:
           path: |
             ~/.cocoapods

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ziggle
 description: ziggle
 publish_to: "none"
-version: 4.3.4
+version: 4.3.5
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Android 빌드 환경에서 사용되는 Java 배포판이 "adopt"에서 "temurin"으로 변경되었습니다.
  * iOS용 CocoaPods 캐시 조건이 'macos-15'에서 'iOS'로 수정되었습니다.
  * 앱 버전이 4.3.4에서 4.3.5로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->