### PR TITLE
fix: group name overflow when it is too long

### DIFF
--- a/lib/app/modules/groups/presentation/pages/group_detail_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_detail_page.dart
@@ -97,41 +97,46 @@ class GroupDetailPage extends StatelessWidget {
                           else
                             Assets.images.groupDefaultProfile.image(width: 90),
                           const SizedBox(width: 15),
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: [
-                                  Text(
-                                    group.name,
-                                    style: TextStyle(
-                                      fontSize: 24,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                    overflow: TextOverflow.ellipsis,
-                                    maxLines: 1,
-                                  ),
-                                  // SizedBox(width: 5),
-                                  // Assets.icons.badgeCheck.svg()
-                                ],
-                              ),
-                              Row(
-                                children: [
-                                  BlocBuilder<NoticeListBloc, NoticeListState>(
-                                    builder: (context, state) {
-                                      return Text(
-                                        t.group.detail
-                                            .noticeCount(n: state.total),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Flexible(
+                                      child: Text(
+                                        group.name,
                                         style: TextStyle(
-                                          fontSize: 16,
-                                          color: Palette.grayText,
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.bold,
                                         ),
-                                      );
-                                    },
-                                  ),
-                                ],
-                              ),
-                            ],
+                                        overflow: TextOverflow.ellipsis,
+                                        maxLines: 1,
+                                      ),
+                                    ),
+                                    // SizedBox(width: 5),
+                                    // Assets.icons.badgeCheck.svg()
+                                  ],
+                                ),
+                                Row(
+                                  children: [
+                                    BlocBuilder<NoticeListBloc,
+                                        NoticeListState>(
+                                      builder: (context, state) {
+                                        return Text(
+                                          t.group.detail
+                                              .noticeCount(n: state.total),
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            color: Palette.grayText,
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
                           )
                         ],
                       ),

--- a/lib/app/modules/groups/presentation/pages/group_detail_page.dart
+++ b/lib/app/modules/groups/presentation/pages/group_detail_page.dart
@@ -114,6 +114,7 @@ class GroupDetailPage extends StatelessWidget {
                                         maxLines: 1,
                                       ),
                                     ),
+                                    // TODO : 그룹 인증 기능 추가 시 개발 필요
                                     // SizedBox(width: 5),
                                     // Assets.icons.badgeCheck.svg()
                                   ],


### PR DESCRIPTION
close #577 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 그룹 상세 페이지에서 그룹명과 알림 개수 영역의 레이아웃 유연성이 개선되어, 긴 그룹명도 화면에 자연스럽게 표시됩니다.  
  * 텍스트 오버플로우 처리가 향상되어 레이아웃이 깔끔하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->