### PR TITLE
fix: ziggle select hint text clickable

### DIFF
--- a/lib/app/modules/common/presentation/widgets/ziggle_select.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_select.dart
@@ -102,14 +102,16 @@ class _ZiggleSelectState<T> extends State<ZiggleSelect<T>> {
                     index == 0 ? null : widget.entries.elementAt(index - 1);
                 return GestureDetector(
                   onTap: () {
-                    widget.onChanged?.call(item?.value);
-                    Future.delayed(
-                      const Duration(milliseconds: 100),
-                      () {
-                        if (!mounted) return;
-                        _overlayController.hide();
-                      },
-                    );
+                    if (index != 0) {
+                      widget.onChanged?.call(item?.value);
+                      Future.delayed(
+                        const Duration(milliseconds: 100),
+                        () {
+                          if (!mounted) return;
+                          _overlayController.hide();
+                        },
+                      );
+                    }
                   },
                   onTapDown: (_) => setState(() {
                     _hovering = item;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 목록의 첫 번째 항목을 탭해도 선택이나 닫힘이 발생하지 않도록 수정했습니다. 이제 첫 항목은 탭 시 동작하지 않으며, 다른 항목은 기존처럼 선택되고 짧은 지연 후 오버레이가 닫힙니다.
  - 의도치 않은 첫 항목 선택으로 인한 값 변경 및 드롭다운 즉시 닫힘 문제를 방지하여 사용성이 향상되었습니다.
  - 기존 탭다운 동작은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->