### PR TITLE
fix: Change padding only to symmetric

### DIFF
--- a/lib/app/modules/notices/presentation/pages/search_page.dart
+++ b/lib/app/modules/notices/presentation/pages/search_page.dart
@@ -149,7 +149,8 @@ class _LayoutState extends State<_Layout> {
                           onLoadMore: () => NoticeListBloc.loadMore(context),
                           slivers: [
                             SliverPadding(
-                              padding: const EdgeInsets.only(left: 16),
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
                               sliver: _buildList(state),
                             ),
                           ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 검색 화면의 가로 패딩을 좌우 동일하게 조정했습니다. 요소들이 화면 가장자리에서 균형 있게 배치되어 레이아웃 일관성과 가독성이 향상됩니다. 작은 화면과 큰 화면 모두에서 좌우 마진이 균등하게 적용되어 시각적 안정감이 높아졌습니다. 기능 동작에는 변화가 없으며, 표시 방식과 간격만 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->