### PR TITLE
📝 fix: Fix incorrect README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔥 ziggle flutter
 
-본 프로젝트는 Flutter 3.24 버전을 기반으로 작성되었습니다.
+본 프로젝트는 Flutter 3.32 버전을 기반으로 작성되었습니다.
 
 [bloc](https://bloclibrary.dev/)을 기반으로 아키텍쳐를 구성했습니다.
 
@@ -55,18 +55,18 @@
 ├── flutter_native_splash.yaml: 앱 스플래시 자동 생성 설정 파일 (dart run flutter_native_splash:create)
 ├── pubspec.lock
 ├── pubspec.yaml: package.json 같은 파일. 앱의 버전, 패키지들이 저장 됨
-└── slang.yaml: 번역을
+└── slang.yaml: 번역을 위한 설정 파일.
 ```
 
 ## 실행법
 
-build_runner를 사용하여 코드를 생성하고, slang을 사용하여 번역 파일을 생성합니다.
+slang을 사용하여 번역 파일을 생성하고, build_runner를 사용하여 코드를 생성합니다.
 
 ```bash
-dart run build_runner build
-dart run build_runner watch
 dart run slang
 dart run slang watch
+dart run build_runner build
+dart run build_runner watch
 ```
 
 또는 watchexec를 사용해서 pubspec.lock 파일이 수정 될 때에
@@ -79,4 +79,10 @@ apt install watchexec
 brew install watchexec
 watchexec -w ./pubspec.lock dart run build_runner watch
 watchexec -r -w ./build.yaml dart run slang watch
+```
+
+IOS 앱 빌드를 위해선 flutterfire_cli가 설치되어야 합니다.
+
+```bash
+dart pub global activate flutterfire_cli
 ```


### PR DESCRIPTION
close #615
- slang, build_runner 순서 변경
- flutter 버전 3.32버전으로 명시
- 자잘한 오타 수정
- IOS 앱 빌드를 위한 flutterfire_cli 설치 방법 명시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서(Documentation)**
  * Flutter 기준 버전 표기를 3.24에서 3.32로 업데이트했습니다.
  * slang 설정 설명을 “번역을 위한 설정 파일”로 명확화했습니다.
  * 실행 절차를 번역 생성(slang) 후 코드 생성(build_runner) 순으로 재정렬하고, 이에 맞춰 예시 코드 블록을 갱신했습니다.
  * iOS 빌드 전제 조건으로 flutterfire_cli 설치 안내를 추가하고 활성화 스니펫을 제공했습니다.
  * 전반적인 문구를 다듬어 가이드를 더 일관되고 이해하기 쉽게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->