### PR TITLE
docs: update instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🔥 ziggle flutter
 
-본 프로젝트는 Flutter 3.24 버전을 기반으로 작성되었습니다.
+본 프로젝트는 Flutter 3.35 버전을 기반으로 작성되었습니다.
 
 [bloc](https://bloclibrary.dev/)을 기반으로 아키텍쳐를 구성했습니다.
 
-```
+```txt
 ├── android: 안드로이드 관련
 │   └── fastlane: 안드로이드 자동 배포
 ├── assets: 앱에서 사용 되는 스태틱 에셋들. pubspec.yaml 파일에서 앱에 포함할 에셋을 설정할 수 있다
@@ -55,18 +55,18 @@
 ├── flutter_native_splash.yaml: 앱 스플래시 자동 생성 설정 파일 (dart run flutter_native_splash:create)
 ├── pubspec.lock
 ├── pubspec.yaml: package.json 같은 파일. 앱의 버전, 패키지들이 저장 됨
-└── slang.yaml: 번역을
+└── slang.yaml: 번역을 위한 설정이 있는 파일
 ```
 
 ## 실행법
 
-build_runner를 사용하여 코드를 생성하고, slang을 사용하여 번역 파일을 생성합니다.
+slang을 사용하여 번역 파일을 생성하고, build_runner를 사용하여 코드를 생성합니다.
 
 ```bash
-dart run build_runner build
-dart run build_runner watch
 dart run slang
 dart run slang watch
+dart run build_runner build
+dart run build_runner watch
 ```
 
 또는 watchexec를 사용해서 pubspec.lock 파일이 수정 될 때에

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔥 ziggle flutter
 
-본 프로젝트는 Flutter 3.35 버전을 기반으로 작성되었습니다.
+본 프로젝트는 Flutter 3.32 버전을 기반으로 작성되었습니다.
 
 [bloc](https://bloclibrary.dev/)을 기반으로 아키텍쳐를 구성했습니다.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서화
  - Flutter 버전 표기를 3.24 → 3.32로 갱신했습니다.
  - 프로젝트 구조 코드 블록 언어를 txt로 명시했습니다.
  - slang.yaml 설명을 “번역을 위한 설정이 있는 파일”로 정리했습니다.
  - assets·lib 섹션의 내용과 프로젝트 트리 설명을 확장·정리했습니다.
  - 실행 순서를 slang → build_runner로 수정했습니다.
  - 명령 예시에 build_runner build/watch를 추가했습니다.
  - watchexec 사용 안내를 보완하고, pubspec.lock 변경 시 build_runner 유지 방법을 안내했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->