### PR TITLE
624 bug language setting not preserved

### DIFF
--- a/lib/app/modules/user/data/models/setting_model.dart
+++ b/lib/app/modules/user/data/models/setting_model.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:ziggle/app/modules/core/domain/enums/language.dart';
 import 'package:ziggle/gen/strings.g.dart';
 
 part 'setting_model.freezed.dart';
@@ -8,12 +9,12 @@ sealed class SettingModel with _$SettingModel {
   const SettingModel._();
 
   const factory SettingModel({
-    required String language,
+    required Language language,
     @Default(false) bool developerOption,
   }) = _SettingModel;
 
   factory SettingModel.init() => SettingModel(
-    language: AppLocaleUtils.findDeviceLocale().name,
+    language: Language.values.byName(AppLocaleUtils.findDeviceLocale().name),
     developerOption: false,
   );
 }

--- a/lib/app/modules/user/data/repositories/hive_setting_repository.dart
+++ b/lib/app/modules/user/data/repositories/hive_setting_repository.dart
@@ -20,12 +20,12 @@ class HiveSettingRepository
 
   @override
   Future<Language> getLanguage() async {
-    return Language.values.byName(_data.language);
+    return _data.language;
   }
 
   @override
   Future<void> setLanguage(Language language) async {
-    await _box.put(_boxKey, _data.copyWith(language: language.name));
+    await _box.put(_boxKey, _data.copyWith(language: language));
   }
 
   @override

--- a/lib/hive/hive_adapters.dart
+++ b/lib/hive/hive_adapters.dart
@@ -7,7 +7,6 @@ import 'package:ziggle/app/modules/user/data/models/setting_model.dart';
 @GenerateAdapters([
   AdapterSpec<SettingModel>(),
   AdapterSpec<NoticeWriteDraftModel>(),
-  AdapterSpec<Language>(),
   AdapterSpec<NoticeType>(),
 ])
 part 'hive_adapters.g.dart';

--- a/lib/hive/hive_adapters.g.yaml
+++ b/lib/hive/hive_adapters.g.yaml
@@ -25,14 +25,6 @@ types:
         index: 3
       deadline:
         index: 4
-  Language:
-    typeId: 3
-    nextIndex: 2
-    fields:
-      ko:
-        index: 0
-      en:
-        index: 1
   NoticeType:
     typeId: 4
     nextIndex: 9

--- a/lib/hive/hive_language_adapters.dart
+++ b/lib/hive/hive_language_adapters.dart
@@ -1,0 +1,19 @@
+import 'package:hive_ce/hive.dart';
+import 'package:ziggle/app/modules/core/domain/enums/language.dart';
+
+class LanguageAdapter extends TypeAdapter<Language> {
+  @override
+  final int typeId = 3; // yaml에서 3이었으니까 여기서도 3으로 지정
+
+  @override
+  Language read(BinaryReader reader) {
+    final index = reader.readByte();
+
+    return Language.values[index];
+  }
+
+  @override
+  void write(BinaryWriter writer, Language obj) {
+    writer.writeByte(obj.index);
+  }
+}

--- a/lib/hive/hive_registrar.g.dart
+++ b/lib/hive/hive_registrar.g.dart
@@ -7,7 +7,6 @@ import 'package:ziggle/hive/hive_adapters.dart';
 
 extension HiveRegistrar on HiveInterface {
   void registerAdapters() {
-    registerAdapter(LanguageAdapter());
     registerAdapter(NoticeTypeAdapter());
     registerAdapter(NoticeWriteDraftModelAdapter());
     registerAdapter(SettingModelAdapter());
@@ -16,7 +15,6 @@ extension HiveRegistrar on HiveInterface {
 
 extension IsolatedHiveRegistrar on IsolatedHiveInterface {
   void registerAdapters() {
-    registerAdapter(LanguageAdapter());
     registerAdapter(NoticeTypeAdapter());
     registerAdapter(NoticeWriteDraftModelAdapter());
     registerAdapter(SettingModelAdapter());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:ziggle/app/values/fonts.dart';
 import 'package:ziggle/app_bloc_observer.dart';
 import 'package:ziggle/firebase_options.dart';
 import 'package:ziggle/gen/strings.g.dart';
+import 'package:ziggle/hive/hive_adapters.dart';
 import 'package:ziggle/hive/hive_registrar.g.dart';
 
 void main() async {
@@ -43,6 +44,7 @@ void _initCrashlytics() {
 Future<void> _initHive() async {
   await Hive.initFlutter();
   Hive.registerAdapters();
+  Hive.registerAdapter(LanguageAdapter());
 }
 
 Future<void> _initLocale() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:ziggle/app/values/fonts.dart';
 import 'package:ziggle/app_bloc_observer.dart';
 import 'package:ziggle/firebase_options.dart';
 import 'package:ziggle/gen/strings.g.dart';
-import 'package:ziggle/hive/hive_adapters.dart';
+import 'package:ziggle/hive/hive_language_adapters.dart';
 import 'package:ziggle/hive/hive_registrar.g.dart';
 
 void main() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,8 +43,8 @@ void _initCrashlytics() {
 
 Future<void> _initHive() async {
   await Hive.initFlutter();
-  Hive.registerAdapters();
   Hive.registerAdapter(LanguageAdapter());
+  Hive.registerAdapters();
 }
 
 Future<void> _initLocale() async {

--- a/slang.yaml
+++ b/slang.yaml
@@ -7,5 +7,5 @@ contexts:
   NoticeCategory:
     generate_enum: false
 imports:
-  - 'package:ziggle/app/modules/notices/domain/enums/notice_type.dart'
-  - 'package:ziggle/app/modules/notices/domain/enums/notice_category.dart'
+  - "package:ziggle/app/modules/notices/domain/enums/notice_type.dart"
+  - "package:ziggle/app/modules/notices/domain/enums/notice_category.dart"


### PR DESCRIPTION
hive_adapters.g.yaml에서 Language는 class가 아닌 Enum이었습니다.
그러나, adapter가 Language를 class로 잘못 판단하고 있었습니다.
기존에는 저장하려는 값이 Language.ko 또는 Language.en 인데, Language가 class로 분류되었으므로 하위 필드가 존재해야했습니다. 그러나, 존재하지 않았기 때문에 직렬화 오류가 발생한 것 같습니다.
그래서, Language는 hive_registrar.g.dart에서 자동으로 adapter를 생성하는 것이 아니라, hive_language_adapters.dart 파일을 따로 만들어서 class로 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 언어 설정 저장·불러오기 안정화
  - 초기 기기 언어 인식 일관성 개선
  - 앱 재시작 후 언어가 기본값으로 되돌아가던 간헐적 문제 해결

- **Refactor**
  - 언어 설정을 문자열에서 enum 기반으로 전환하여 타입 안정성과 호환성 향상

- **Chores**
  - 앱 초기화 시 언어 어댑터 등록 추가로 다국어 데이터 처리 신뢰성 개선
  - 설정 관련 구성 파일 포맷 경미 조정(동작 영향 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->