### PR TITLE
fix(cd): android symbol path

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :android do
 
     android_app_id = File.open("../../lib/firebase_options.dart").read().match(/appId: '(.*android.*)'/)[1]
     UI.message("Android App ID: #{android_app_id}")
-    debug_info_path = "build/app/outputs/symbols"
+    debug_info_path = "debug-info"
 
     sh(
       "flutter", "build", "appbundle",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Android 빌드 설정에서 디버그 심볼 저장 경로를 업데이트했습니다. 이는 Firebase 충돌 보고 시스템이 필요한 정보를 더 정확하게 수집할 수 있도록 개선합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->