### PR TITLE
ci: iOS 빌드 러너를 macos-26으로 변경

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-os: [ubuntu-latest, macos-15]
+        build-os: [ubuntu-latest, macos-26]
         include:
           - build-os: ubuntu-latest
             os: Android
-          - build-os: macos-15
+          - build-os: macos-26
             os: iOS
     runs-on: ${{ matrix.build-os }}
     concurrency:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-os: [ubuntu-latest, macos-15]
+        build-os: [ubuntu-latest, macos-26]
         include:
           - os: Android
             build-os: ubuntu-latest
           - os: iOS
-            build-os: macos-15
+            build-os: macos-26
     name: Build ${{ matrix.os }} App and Upload
     runs-on: ${{ matrix.build-os }}
     concurrency:


### PR DESCRIPTION
App Store Connect가 iOS 26 SDK 미만으로 빌드된 앱의 업로드를 거부하면서 TestFlight 업로드가 실패했다.

  Validation failed (409) SDK version issue. This app was built with the
  iOS 18.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK
  or later, included in Xcode 26 or later, in order to be uploaded to
  App Store Connect or submitted for distribution.

macos-15 러너의 기본 Xcode는 16.4(iOS 18.5 SDK)라서 조건을 만족하지 못한다. macos-26 러너는 기본 Xcode가 26.6(iOS 26.5 SDK)이므로 러너 이미지만 교체한다.

Flutter 3.35.7 + Xcode 26.6 조합은 로컬에서 `flutter build ios` 성공을 확인했다.

production.yml은 deliver를 skip_binary_upload로 호출해 바이너리를 빌드하지 않으므로 변경하지 않는다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI 및 빌드**
  * macOS 테스트와 iOS 빌드 환경을 `macos-26`으로 업데이트했습니다.
  * Android 실행 환경은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->