### PR TITLE
fix(cd): crashlytics 심볼 업로드 경로 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-os: [ubuntu-latest, macos-15]
+        build-os: [ubuntu-latest, macos-26]
         include:
           - build-os: ubuntu-latest
             os: Android
-          - build-os: macos-15
+          - build-os: macos-26
             os: iOS
     runs-on: ${{ matrix.build-os }}
     concurrency:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-os: [ubuntu-latest, macos-15]
+        build-os: [ubuntu-latest, macos-26]
         include:
           - os: Android
             build-os: ubuntu-latest
           - os: iOS
-            build-os: macos-15
+            build-os: macos-26
     name: Build ${{ matrix.os }} App and Upload
     runs-on: ${{ matrix.build-os }}
     concurrency:

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :android do
 
     android_app_id = File.open("../../lib/firebase_options.dart").read().match(/appId: '(.*android.*)'/)[1]
     UI.message("Android App ID: #{android_app_id}")
-    debug_info_path = "debug-info"
+    debug_info_path = File.expand_path("../../debug-info")
 
     sh(
       "flutter", "build", "appbundle",
@@ -33,11 +33,15 @@ platform :android do
       "--build-number=#{build_number}",
     )
 
+    unless Dir.exist?(debug_info_path)
+      UI.user_error!("Debug info not found at #{debug_info_path}")
+    end
+
     sh(
       "firebase",
       "crashlytics:symbols:upload",
       "--app=#{android_app_id}",
-      File.expand_path("../../#{debug_info_path}")
+      debug_info_path
     )
 
     symbols_path = File.expand_path("../../build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib")


### PR DESCRIPTION
## 문제

Android CD의 `firebase crashlytics:symbols:upload` 단계가 계속 실패했습니다.

```
java.io.IOException: Unstripped native library path does not exist:
/home/runner/work/ziggle-flutter/ziggle-flutter/debug-info
```

## 원인

fastlane의 작업 디렉터리는 `android/fastlane` 입니다. 그런데
- `flutter build` 에는 **상대경로** `--split-debug-info=debug-info` 를 넘겨서 심볼이 `android/fastlane/debug-info` 에 생성되고,
- 업로드는 `File.expand_path("../../debug-info")` 즉 **레포 루트**를 참조했습니다.

두 경로가 어긋나서 업로드 시점에 디렉터리가 없다고 실패한 것입니다.

## 수정

- `debug_info_path` 를 절대경로로 계산해 빌드와 업로드가 같은 경로를 쓰도록 했습니다.
- 빌드 직후 디렉터리 존재를 검사해, 경로가 또 어긋나면 firebase 스택트레이스 대신 명확한 메시지로 즉시 실패합니다.
