### PR TITLE
fix(ios): restore MinimumOSVersion for App.framework

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,5 +20,7 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
+  <key>MinimumOSVersion</key>
+  <string>15.6</string>
 </dict>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * iOS 앱의 최소 지원 버전이 15.6으로 설정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->