### PR TITLE
fix(ios): lay out the native tab bar for regular widths on iPad

### DIFF
--- a/lib/app/modules/common/presentation/pages/ziggle_bottom_navigation_page.dart
+++ b/lib/app/modules/common/presentation/pages/ziggle_bottom_navigation_page.dart
@@ -55,6 +55,14 @@ class _ZiggleBottomNavigationPageState extends State<ZiggleBottomNavigationPage>
       return;
     }
     setState(() => _chatbotOpen = true);
+    if (ZiggleNavigationBar.isNative) {
+      // Let the native bar and button slide off screen first. The modal's
+      // blurred backdrop cannot cover platform views, so they would show
+      // through it, and the glass views paint a black outline while a blur
+      // is composited over them.
+      await Future<void>.delayed(ZiggleNavigationBar.hideDuration);
+      if (!mounted) return;
+    }
     try {
       _chatbot ??= GistChatbot(
         config: GistChatbotConfig(

--- a/lib/app/modules/common/presentation/pages/ziggle_bottom_navigation_page.dart
+++ b/lib/app/modules/common/presentation/pages/ziggle_bottom_navigation_page.dart
@@ -34,6 +34,10 @@ class _ZiggleBottomNavigationPageState extends State<ZiggleBottomNavigationPage>
   GistChatbot? _chatbot;
   bool _chatbotOpen = false;
 
+  /// Bumped whenever the chatbot is reset, so an open that is still waiting
+  /// for the bar to slide away does not resume under a different account.
+  int _chatbotSession = 0;
+
   /// A route is stacked above this shell, so the native bar must leave the
   /// screen: a platform view would otherwise linger under the pushed page.
   bool _covered = false;
@@ -60,8 +64,14 @@ class _ZiggleBottomNavigationPageState extends State<ZiggleBottomNavigationPage>
       // blurred backdrop cannot cover platform views, so they would show
       // through it, and the glass views paint a black outline while a blur
       // is composited over them.
+      final session = _chatbotSession;
       await Future<void>.delayed(ZiggleNavigationBar.hideDuration);
       if (!mounted) return;
+      if (session != _chatbotSession) {
+        // The account changed while waiting; bring the bar back instead.
+        setState(() => _chatbotOpen = false);
+        return;
+      }
     }
     try {
       _chatbot ??= GistChatbot(
@@ -84,6 +94,7 @@ class _ZiggleBottomNavigationPageState extends State<ZiggleBottomNavigationPage>
   }
 
   void _resetChatbot() {
+    _chatbotSession++;
     // Let the modal finish its reverse transition before disposing its controller.
     final chatbot = _chatbot;
     _chatbot = null;

--- a/lib/app/modules/common/presentation/widgets/ziggle_navigation_bar.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_navigation_bar.dart
@@ -76,8 +76,10 @@ class ZiggleNavigationBar extends StatelessWidget {
   /// iPad split view) and stacks the tab items.
   static const _regularWidth = 600.0;
 
-  /// Slide-away time while a route covers the native bar.
-  static const _hideDuration = Duration(milliseconds: 200);
+  /// Slide-away time while a route covers the native bar. Callers that open
+  /// a modal over the native bar should wait this long after setting
+  /// [obscured] before pushing, so no platform view is left under the modal.
+  static const hideDuration = Duration(milliseconds: 200);
 
   static List<String> _labels(BuildContext context) => [
     context.t.navigation.home,
@@ -135,7 +137,7 @@ class ZiggleNavigationBar extends StatelessWidget {
           ignoring: obscured,
           child: AnimatedSlide(
             offset: obscured ? const Offset(0, 1) : Offset.zero,
-            duration: _hideDuration,
+            duration: hideDuration,
             curve: Curves.easeInOut,
             child: Stack(
               children: [

--- a/lib/app/modules/common/presentation/widgets/ziggle_navigation_bar.dart
+++ b/lib/app/modules/common/presentation/widgets/ziggle_navigation_bar.dart
@@ -10,8 +10,12 @@ import 'package:ziggle/gen/strings.g.dart';
 
 /// Popo wearing a headset, rasterised from `assets/icons/chatbot.svg` at
 /// 33 pt with strokes matching the tab icons' weight. Not a template image:
-/// it carries its own black and white.
-final _chatIcon = Assets.icons.chatbotPng.image();
+/// it carries its own black and white. [width] scales it for smaller buttons.
+Widget _chatIcon({double? width}) =>
+    Assets.icons.chatbotPng.image(width: width);
+
+/// Mascot width that fits a chat button of [buttonSize].
+double _chatIconWidth(double buttonSize) => buttonSize * 33 / 60;
 
 /// Bottom navigation for the three destinations.
 ///
@@ -46,6 +50,12 @@ class ZiggleNavigationBar extends StatelessWidget {
   /// and takes [ZiggleChatbotButton] in that slot instead.
   static bool get isNative => PlatformInfo.isIOS26OrHigher();
 
+  // Native bar geometry, measured on iOS 26.5. UITabBar changes its layout
+  // with the horizontal size class, so there are two sets of metrics.
+  //
+  // Compact width (iPhone): items stack icon over label, the pill is 60 pt
+  // tall and stops widening at 270 pt, so its edges are predictable and the
+  // chat button can sit a fixed gap beside it.
   static const _chatSize = 60.0;
   static const _chatGap = 12.0;
   static const _edgeMargin = 22.0;
@@ -55,6 +65,16 @@ class ZiggleNavigationBar extends StatelessWidget {
 
   /// UITabBar stops widening the pill once three items have this much room.
   static const _pillMaxWidth = 270.0;
+
+  // Regular width (iPad): items go inline, icon beside label, so the pill's
+  // width follows the label text and cannot be predicted. The bar spans the
+  // full width and UIKit centres the pill itself; the 46 pt chat button is
+  // pinned to the trailing edge instead of beside the pill.
+  static const _regularChatSize = 46.0;
+
+  /// Below this width UIKit treats the window as compact (iPhone, narrow
+  /// iPad split view) and stacks the tab items.
+  static const _regularWidth = 600.0;
 
   /// Slide-away time while a route covers the native bar.
   static const _hideDuration = Duration(milliseconds: 200);
@@ -82,14 +102,30 @@ class ZiggleNavigationBar extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
-        final pillWidth = min(
-          _pillMaxWidth,
-          width - 2 * _edgeMargin - _chatGap - _chatSize,
-        );
-        final side = (width - pillWidth - _chatGap - _chatSize) / 2;
-        final chatLeft = side + pillWidth + _chatGap;
+        final regular = width >= _regularWidth;
+        final double barLeft;
+        final double barRight;
+        final double chatLeft;
+        final double chatSize;
+        if (regular) {
+          barLeft = 0;
+          barRight = 0;
+          chatSize = _regularChatSize;
+          chatLeft = width - _edgeMargin - chatSize;
+        } else {
+          final pillWidth = min(
+            _pillMaxWidth,
+            width - 2 * _edgeMargin - _chatGap - _chatSize,
+          );
+          final side = (width - pillWidth - _chatGap - _chatSize) / 2;
+          barLeft = side - _nativeInset;
+          barRight = width - side - pillWidth - _nativeInset;
+          chatSize = _chatSize;
+          chatLeft = side + pillWidth + _chatGap;
+        }
         // The bar keeps its intrinsic height, which already covers the home
-        // indicator; it draws the pill in its top 60 points.
+        // indicator; it draws the pill at its top edge, 60 pt tall on compact
+        // widths and 46 pt on regular ones, which the chat button matches.
         //
         // While a route covers the shell the whole row slides below the
         // screen. Liquid Glass views cannot be hidden or faded without
@@ -104,10 +140,7 @@ class ZiggleNavigationBar extends StatelessWidget {
             child: Stack(
               children: [
                 Padding(
-                  padding: EdgeInsets.only(
-                    left: side - _nativeInset,
-                    right: width - side - pillWidth - _nativeInset,
-                  ),
+                  padding: EdgeInsets.only(left: barLeft, right: barRight),
                   child: NativeTabBarHost(
                     destinations: [
                       for (var i = 0; i < labels.length; i++)
@@ -127,7 +160,7 @@ class ZiggleNavigationBar extends StatelessWidget {
                   top: 0,
                   left: chatLeft,
                   child: SizedBox.square(
-                    dimension: _chatSize,
+                    dimension: chatSize,
                     child: Semantics(
                       label: context.t.navigation.chatbot,
                       button: true,
@@ -137,9 +170,9 @@ class ZiggleNavigationBar extends StatelessWidget {
                         onPressed: onChatbotPressed,
                         style: IOS26ButtonStyle.glass,
                         color: Palette.black,
-                        borderRadius: BorderRadius.circular(_chatSize / 2),
+                        borderRadius: BorderRadius.circular(chatSize / 2),
                         useSmoothRectangleBorder: false,
-                        child: _chatIcon,
+                        child: _chatIcon(width: _chatIconWidth(chatSize)),
                       ),
                     ),
                   ),
@@ -244,7 +277,7 @@ class ZiggleChatbotButton extends StatelessWidget {
           ),
           child: SizedBox.square(
             dimension: _size,
-            child: Center(child: _chatIcon),
+            child: Center(child: _chatIcon()),
           ),
         ),
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * iPad와 같은 넓은 화면에서 네이티브 내비게이션 바가 전체 너비로 표시되고, 채팅 버튼이 오른쪽 끝에 배치됩니다.
  * 좁은 화면에서는 기존 내비게이션 바 레이아웃이 유지됩니다.
  * 챗봇을 열 때 내비게이션 바가 완전히 사라진 후 모달이 표시되어, 배경 흐림 효과의 시각적 문제와 검은 테두리 현상이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->