### PR TITLE
fix: handle legacy consent field type

### DIFF
--- a/lib/app/modules/user/data/models/user_model.dart
+++ b/lib/app/modules/user/data/models/user_model.dart
@@ -4,7 +4,7 @@ import 'package:ziggle/app/modules/user/domain/entities/user_entity.dart';
 part 'user_model.freezed.dart';
 part 'user_model.g.dart';
 
-@freezed
+@Freezed(fromJson: true)
 sealed class UserModel with _$UserModel implements UserEntity {
   const UserModel._();
 
@@ -19,6 +19,12 @@ sealed class UserModel with _$UserModel implements UserEntity {
     DateTime? consent,
   }) = _UserModel;
 
-  factory UserModel.fromJson(Map<String, dynamic> json) =>
-      _$UserModelFromJson(json);
+  factory UserModel.fromJson(Map<String, dynamic> json) {
+    if (json['consent'] is bool) {
+      json['consent'] = json['consent']
+          ? DateTime.now().toIso8601String()
+          : null;
+    }
+    return _$UserModelFromJson(json);
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 사용자 동의 정보가 불리언 값으로 제공될 때 올바르게 처리되도록 개선했습니다.
  - 동의한 경우 현재 시각이 기록되며, 동의하지 않은 경우 동의 기록이 비어 있는 상태로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->